### PR TITLE
Add weight initialisation, dropout, and cosine annealing lr scheduler

### DIFF
--- a/src/vit_prisma/configs/HookedViTConfig.py
+++ b/src/vit_prisma/configs/HookedViTConfig.py
@@ -99,10 +99,13 @@ class HookedViTConfig:
     warmup_steps: int = 10
     scheduler_step: int = 200
     scheduler_gamma: float = .8
+    scheduler_type: str = "WarmupThenStep"
     early_stopping: bool = False
     early_stopping_patience: int = 2
     num_epochs: int = 50
     max_grad_norm = 1.0
+    attn_dropout_rate: float = 0.0
+    mlp_dropout_rate: float = 0.0
 
     # Saving related
     parent_dir: str = ""

--- a/src/vit_prisma/models/base_vit.py
+++ b/src/vit_prisma/models/base_vit.py
@@ -218,6 +218,19 @@ class HookedViT(HookedRootModule):
             for m in self.modules(): 
                 if isinstance(m, PosEmbedding):
                     nn.init.normal_(m.W_pos, std=self.cfg.pos_std)
+                elif isinstance(m, Attention):
+                    nn.init.xavier_uniform_(m.W_Q)
+                    nn.init.xavier_uniform_(m.W_K)
+                    nn.init.xavier_uniform_(m.W_V)
+                    nn.init.xavier_uniform_(m.W_O)
+                elif isinstance(m, MLP):
+                    nn.init.kaiming_normal_(m.W_in, nonlinearity='relu')
+                    nn.init.kaiming_normal_(m.W_out, nonlinearity='relu')
+                    nn.init.zeros_(m.b_out)
+                    nn.init.zeros_(m.b_in)
+                elif isinstance(m, Head):
+                    nn.init.kaiming_normal_(m.W_H, nonlinearity='relu')
+                    nn.init.zeros_(m.b_H)
                 elif isinstance(m, nn.Linear) or isinstance(m, nn.Conv2d):
                     nn.init.kaiming_normal_(m.weight, nonlinearity='relu')
                     if m.bias is not None:

--- a/src/vit_prisma/prisma_tools/loading_from_pretrained.py
+++ b/src/vit_prisma/prisma_tools/loading_from_pretrained.py
@@ -669,15 +669,12 @@ def convert_pretrained_model_config(model_name: str, is_timm: bool = True, is_cl
             "return_type": "class_logits" # actually returns 'visual_projection'
         })
 
-<<<<<<< HEAD
     if "dino" in model_name:
         pretrained_config.update({
             "return_type": "pre_logits",
             "n_classes": 768,
         })
 
-=======
->>>>>>> sonia-open-clip-acc-baseline
     # Config is for ViVet, need to add more properties
     if hasattr(hf_config, "tubelet_size"):
         pretrained_config.update({

--- a/src/vit_prisma/training/trainer.py
+++ b/src/vit_prisma/training/trainer.py
@@ -57,7 +57,13 @@ def train(
     print(f"Length of testloader {len(test_loader)}")
     steps = 0
 
-    scheduler = WarmupThenStepLR(optimizer, warmup_steps=config.warmup_steps, step_size=config.scheduler_step, gamma=config.scheduler_gamma)
+    if config.scheduler_type == "WarmupThenStepLR":
+        scheduler = WarmupThenStepLR(optimizer, warmup_steps=config.warmup_steps, step_size=config.scheduler_step, gamma=config.scheduler_gamma)
+    elif config.scheduler_type == "CosineAnnealing":
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, config.num_epochs)
+    else:
+        raise ValueError("Scheduler type {} not supported (only 'WarmupThenStep' and "
+                         "'CosineAnnealing'")
 
     if config.early_stopping:
         early_stopping = EarlyStopping(patience=config.early_stopping_patience, verbose=True)


### PR DESCRIPTION
I was using the package (it's great - thanks!) to train a ViT for CIFAR-10 (and do some mechinterp experiments) and ran into a few issues, and these are the minimal changes I made to resolve them - thought I'd add here in case they are useful.

1. The `Attention` and `MLP` classes were not being initialised (they use `torch.empty` which I believe just initialises the values with those previously in that memory location) and I was getting `NaN` errors, so I added to the `init_weights()` method to explicitly initialise them. 
2. I needed dropout and so added this via the `attn_dropout_rate` and `mlp_dropout_rate` config.
3. I also added a `scheduler_type` config to swap between different lr schedulers.

I do not add tests, but can do if desired.

I also remove a left over git string that seems to be breaking the tests.
