### PR TITLE
🐛 Fixing Dependencies in Setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,9 @@ install_requires = [
     'transformers', # Test dependency
     'scikit-learn', # Test dependency
     'datasets',
-    'line_profiler'
-    
+    'line_profiler',
+    'matplotlib',
+    'wandb',    
 ]
 
 setup(


### PR DESCRIPTION
Fixing the import of  [wandb](https://github.com/soniajoseph/ViT-Prisma/blob/7b147c5e03a0a639d4f13889cddcae2ac1153a39/src/vit_prisma/sae/train_sae.py#L13) and [matplotlib](https://github.com/soniajoseph/ViT-Prisma/blob/7b147c5e03a0a639d4f13889cddcae2ac1153a39/src/vit_prisma/sae/evals/eval_neuron_basis.py#L8)


