### PR TITLE
Reimplement SAE training eval code

### DIFF
--- a/docs/sae_experiment_tracking.md
+++ b/docs/sae_experiment_tracking.md
@@ -1,0 +1,84 @@
+# SAE Experiment Logging and Tracking
+
+An objective we have when training an SAE is to have a small number of non-zero elements in the hidden layer (i.e. a small L0 'norm'). The L1 norm is used as a proxy for this.
+
+The loss term of the SAE is:
+
+$$loss = mse + l1\_coeff * sparsity + [ \: ghost \: gadients \: ]$$
+
+The two loss term in the SAE loss function have conflicting goals:
+* The **reconstruction term** (MSE) works to make the autoencoder good at reconstructing the input.
+* The **sparsity** term works to reduce the magnitudes in the hidden layer. 
+
+When training an SAE most metrics are related to measuring reconstruction loss vs sparsity, in different ways. The goal is to monitor these and find pareto improvements.
+
+Weights and Biases is used to track experiments (toggled with `VisionModelSAERunnerConfig.log_to_wandb`)
+
+# Validation
+
+Whilst training an SAE validation metrics are logged every `VisionModelSAERunnerConfig.wandb_log_frequency` steps, whilst the sparsity is logged every `VisionModelSAERunnerConfig.feature_sampling_window` steps. Note that each step is `VisionModelSAERunnerConfig.train_batch_size` number of tokens, for a total of (num_images x num_epochs x tokens_per_image / training_batch) steps.
+
+During validation the following matrics are logged:
+
+#### plots
+
+* `log_feature_density_histogram` - every step since the last log the number of feature activations that are greater than 0 divided by the total amount. See [here](https://arena3-chapter1-transformer-interp.streamlit.app/[1.3.2]_Interpretability_with_SAEs) for a discussion on how to interpret this. 
+
+#### details
+
+* `details/current_learning_rate` - The learning rate at each step of training.
+* `details/n_training_tokens` - The number of training tokens seen so far (Images x tokens per image)
+* `details/n_training_images` - The number of training images seen so far
+
+#### losses
+
+* `losses/mse_loss` - The normalised MSE loss between the SAE input and output, i.e. the reconstruction loss. Normalised such that it is less dependent on the size of the input/output. 
+* `losses/l1_loss`
+* `losses/ghost_grad_loss` - this describes the method of adding an additional term to the loss, which essentially gives dead latents a gradient signal that pushes them in the direction of explaining more of the autoencoder's residual.
+`losses/overall_loss`
+
+#### metrics
+
+
+* `metrics/explained_variance` - explained variance is the ratio of the variance in the reconstructed data to the variance in the original input data. A higher explained variance indicates that the SAE has learned features that capture more of the meaningful structure in the data. This is the mean over the batch.
+* `metrics/explained_variance_std` - This is the std over the batch.
+* `metrics/l0` - the feature activations for that step greater than 0 summed together, and the mean over the batch.
+* `metrics/mean_log10_feature_sparsity`
+
+#### sparsity
+
+* `sparsity/mean_passes_since_fired` - For each activation, Tracks the number of training tokens (images x tokens per image) since activation was greater than 0
+* `sparsity/dead_features`
+* `sparsity/below_1e-5` - feature_sparsity < 1e-5
+* `sparsity/below_1e-6` - feature_sparsity < 1e-6
+
+# Evaluation
+
+There are two types of evaluation, namely that which is called during training and after training. This is because it is a costly procedure and the `TrainingEvalConfig` defines an evaluation run that is performed multiple times during training to give an idea of SAE performance and `PostTrainingEvalConfig` which aims to give a full breakdown of model performance. 
+
+## Training Evaluation
+
+Whilst training an SAE the training evaluation will run every `EvalConfig.log_frequency` and a post-training evaluation will run at the end. A training run can be kicked off with: 
+
+TODO EdS: Document which evals are available
+
+```python
+cfg = VisionModelSAERunnerConfig()
+trainer = VisionSAETrainer(cfg)
+sae = trainer.run()
+```
+
+## Post-Training Evaluation
+
+To manually kick off a post-training evaluation on a saved SAE:
+
+```python
+model = load_model(cfg)
+sae = load_sae(cfg)
+train_data, val_data, val_data_visualize = load_dataset(cfg)
+wandb.init(project=cfg.wandb_project, name=cfg.run_name)
+evaluator = Evaluator(model, val_data, cfg, visualize_data=val_data_visualize)
+evaluator.evaluate(sae, context="post-training")
+```
+
+TODO EdS: CLI implementation for evaluation

--- a/src/vit_prisma/sae/evals/eval_utils.py
+++ b/src/vit_prisma/sae/evals/eval_utils.py
@@ -1,0 +1,585 @@
+import os
+import textwrap
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, List
+from typing import Tuple, Dict
+
+import einops
+import numpy as np
+import plotly.express as px
+import requests
+import torch
+import torch.nn.functional as F
+import wandb
+from plotly.io import write_image
+
+from vit_prisma.models.base_vit import HookedViT
+from vit_prisma.sae.config import VisionModelSAERunnerConfig
+from vit_prisma.sae.sae import SparseAutoencoder
+
+
+@dataclass
+class EvalStats:
+    """Evaluation statistics for the quality of an SAE:
+    - avg_loss: Average total loss.
+    - avg_cos_sim: Average cosine similarity between original and reconstructed
+        activations.
+    - avg_reconstruction_loss: Average reconstruction loss.
+    - avg_zero_abl_loss: Average zero ablation loss.
+    - avg_l0: Average L0 sparsity (features activated) per token.
+    - avg_l0_cls: Average L0 sparsity for CLS tokens.
+    - avg_l0_image: Average L0 sparsity per image.
+    - log_frequencies_per_token: Log frequencies of feature activations per token.
+    - log_frequencies_per_image: Log frequencies of feature activations per image.
+    """
+
+    avg_loss: float
+    avg_cos_sim: np.floating
+    avg_reconstruction_loss: float
+    avg_zero_abl_loss: float
+    avg_l0: np.floating
+    avg_l0_cls: np.floating
+    avg_l0_image: np.floating
+    log_frequencies_per_token: np.array
+    log_frequencies_per_image: np.array
+
+    def __repr__(self):
+        fields = [f"{key}={repr(value)}" for key, value in self.__dict__.items()]
+        return f"{self.__class__.__name__}(\n  " + ",\n  ".join(fields) + "\n)"
+
+
+@torch.no_grad()
+def get_recons_loss(
+    sparse_autoencoder: SparseAutoencoder,
+    model: HookedViT,
+    batch_tokens: torch.Tensor,
+    gt_labels: torch.Tensor,
+    all_labels: List[str],
+    text_embeddings: torch.Tensor,
+    device: torch.device = torch.device("cuda" if torch.cuda.is_available() else "cpu"),
+):
+    # Move model to device if it's not already there
+    model = model.to(device)
+
+    # Move all tensors to the same device
+    batch_tokens = batch_tokens.to(device)
+    gt_labels = gt_labels.to(device)
+    text_embeddings = text_embeddings.to(device)
+
+    # Get image embeddings
+    image_embeddings, _ = model.run_with_cache(batch_tokens)
+
+    # Calculate similarity scores
+    softmax_values, top_k_indices = get_similarity(
+        image_embeddings, text_embeddings, device=device
+    )
+
+    # Calculate cross-entropy loss
+    loss = F.cross_entropy(softmax_values, gt_labels)
+    # Safely extract the loss value
+    loss_value = loss.item() if torch.isfinite(loss).all() else float("nan")
+
+    head_index = sparse_autoencoder.cfg.hook_point_head_index
+    hook_point = sparse_autoencoder.cfg.hook_point
+
+    def standard_replacement_hook(activations: torch.Tensor, hook: Any):
+        activations = sparse_autoencoder.forward(activations)[0].to(activations.dtype)
+        return activations
+
+    def head_replacement_hook(activations: torch.Tensor, hook: Any):
+        new_activations = sparse_autoencoder.forward(activations[:, :, head_index])[
+            0
+        ].to(activations.dtype)
+        activations[:, :, head_index] = new_activations
+        return activations
+
+    replacement_hook = (
+        standard_replacement_hook if head_index is None else head_replacement_hook
+    )
+
+    recons_image_embeddings = model.run_with_hooks(
+        batch_tokens,
+        fwd_hooks=[(hook_point, partial(replacement_hook))],
+    )
+    recons_softmax_values, _ = get_similarity(
+        recons_image_embeddings, text_embeddings, device=device
+    )
+    recons_loss = F.cross_entropy(recons_softmax_values, gt_labels)
+
+    zero_abl_image_embeddings = model.run_with_hooks(
+        batch_tokens, fwd_hooks=[(hook_point, zero_ablate_hook)]
+    )
+    zero_abl_softmax_values, _ = get_similarity(
+        zero_abl_image_embeddings, text_embeddings, device=device
+    )
+    zero_abl_loss = F.cross_entropy(zero_abl_softmax_values, gt_labels)
+
+    score = (zero_abl_loss - recons_loss) / (zero_abl_loss - loss)
+
+    return score, loss, recons_loss, zero_abl_loss
+
+
+def get_similarity(image_features, text_features, k=5, device="cuda"):
+    image_features = image_features.to(device)
+    text_features = text_features.to(device)
+
+    softmax_values = (image_features @ text_features.T).softmax(dim=-1)
+    top_k_values, top_k_indices = torch.topk(softmax_values, k, dim=-1)
+    return softmax_values, top_k_indices
+
+
+def zero_ablate_hook(activations: torch.Tensor, hook: Any):
+    activations = torch.zeros_like(activations)
+    return activations
+
+
+def get_feature_probability(feature_acts):
+    return (feature_acts.abs() > 0).float().flatten(0, 1)
+
+
+def get_text_labels(name="wordbank"):
+    """
+    Loads the library of logit labels from a GitHub URL.
+
+    Returns:
+    list: A list of string labels.
+    """
+    if name == "wordbank":
+        url = "https://raw.githubusercontent.com/yossigandelsman/clip_text_span/main/text_descriptions/image_descriptions_general.txt"
+        try:
+            # Fetch the content from the URL
+            response = requests.get(url)
+            response.raise_for_status()  # Raise an exception for bad status codes
+
+            # Split the content into lines and strip whitespace
+            all_labels = [line.strip() for line in response.text.splitlines()]
+
+            print(f"Number of labels loaded: {len(all_labels)}")
+            print(f"First 5 labels: {all_labels[:5]}")
+            return all_labels
+
+        except requests.RequestException as e:
+            print(f"An error occurred while fetching the labels: {e}")
+            return []
+    elif name == "imagenet":
+        from vit_prisma.dataloaders.imagenet_dataset import get_imagenet_text_labels
+
+        return get_imagenet_text_labels()
+    else:
+        raise ValueError(f"Invalid label set name: {name}")
+
+
+def get_text_embeddings(model_name, original_text, batch_size=32):
+    from transformers import CLIPProcessor, CLIPModel
+
+    vanilla_model = CLIPModel.from_pretrained(model_name)
+    processor = CLIPProcessor.from_pretrained(model_name, do_rescale=False)
+
+    # Split the text into batches
+    text_batches = [
+        original_text[i : i + batch_size]
+        for i in range(0, len(original_text), batch_size)
+    ]
+
+    all_embeddings = []
+
+    for batch in text_batches:
+        inputs = processor(
+            text=batch,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=77,
+        )
+        # inputs = {k: v.to(cfg.device) for k, v in inputs.items()}
+
+        with torch.no_grad():
+            text_embeddings = vanilla_model.get_text_features(**inputs)
+
+        text_embeddings = text_embeddings / text_embeddings.norm(dim=-1, keepdim=True)
+        all_embeddings.append(text_embeddings)
+
+    # Concatenate all batches
+    final_embeddings = torch.cat(all_embeddings, dim=0)
+
+    return final_embeddings
+
+
+def calculate_log_frequencies(
+    total_acts, total_tokens, cfg: VisionModelSAERunnerConfig
+):
+    print("Calculating log frequencies...") if cfg.verbose else None
+    # print out all shapes
+    print("total_acts shape", total_acts.shape) if cfg.verbose else None
+    feature_probs = total_acts / total_tokens
+    log_feature_probs = torch.log10(feature_probs + 1e-6)
+    return log_feature_probs.cpu().numpy()
+
+
+def visualize_sparsities(
+    cfg,
+    log_freq_tokens,
+    log_freq_images,
+    conditions,
+    condition_texts,
+    name,
+    sparse_autoencoder,
+):
+    """Plot the feature density histograms for both the number of feature activations
+    on both a per token and per image level. This is a good indicator of SAE quality.
+    """
+    print(f"Saving sparsity histograms to: {cfg.sae_path + '/sparsity_histograms'}")
+    # Visualise sparsities for each instance
+    hist(
+        cfg,
+        log_freq_tokens,
+        f"{name}_frequency_tokens_histogram",
+        show=False,
+        to_wandb=True,
+        title=f"{name} Log Frequency of Features by Token",
+        labels={"x": "log<sub>10</sub>(freq)"},
+        histnorm="percent",
+        template="ggplot2",
+    )
+    hist(
+        cfg,
+        log_freq_images,
+        f"{name}_frequency_images_histogram",
+        show=False,
+        to_wandb=True,
+        title=f"{name} Log Frequency of Features by Image",
+        labels={"x": "log<sub>10</sub>(freq)"},
+        histnorm="percent",
+        template="ggplot2",
+    )
+
+    # TODO these conditions need to be tuned to distribution of your data!
+
+    for condition, condition_text in zip(conditions, condition_texts):
+        percentage = (
+            torch.count_nonzero(condition) / log_freq_tokens.shape[0]
+        ).item() * 100
+        if percentage == 0:
+            continue
+        percentage = int(np.round(percentage))
+        rare_encoder_directions = sparse_autoencoder.W_enc[:, condition]
+        rare_encoder_directions_normalized = (
+            rare_encoder_directions / rare_encoder_directions.norm(dim=0, keepdim=True)
+        )
+
+        # Compute their pairwise cosine similarities & sample randomly from this N*N matrix of similarities
+        cos_sims_rare = (
+            rare_encoder_directions_normalized.T @ rare_encoder_directions_normalized
+        ).flatten()
+        cos_sims_rare_random_sample = cos_sims_rare[
+            torch.randint(0, cos_sims_rare.shape[0], (10000,))
+        ]
+
+        # Plot results
+        hist(
+            cfg,
+            cos_sims_rare_random_sample,
+            f"{name}_low_prop_similarity_{condition_text}",
+            show=False,
+            to_wandb=True,
+            marginal="box",
+            title=f"{name} Cosine similarities of random {condition_text} <br> encoder directions with each other ({percentage}% of features)",
+            labels={"x": "Cosine sim"},
+            histnorm="percent",
+            template="ggplot2",
+        )
+
+
+def get_intervals_for_sparsities(log_freq):
+    # Define intervals and conditions
+    intervals = [
+        (-8, -6),
+        (-6, -5),
+        (-5, -4),
+        (-4, -3),
+        (-3, -2),
+        (-2, -1),
+        (-float("inf"), -8),
+        (-1, float("inf")),
+    ]
+
+    conditions = [
+        torch.logical_and(log_freq >= lower, log_freq < upper)
+        for lower, upper in intervals
+    ]
+    condition_texts = [f"TOTAL_logfreq_[{lower},{upper}]" for lower, upper in intervals]
+
+    # Replace infinity with appropriate text for readability
+    condition_texts[-2] = condition_texts[-2].replace("-inf", "-∞")
+    condition_texts[-1] = condition_texts[-1].replace("inf", "∞")
+    return intervals, conditions, condition_texts
+
+
+def highest_activating_tokens(
+    images,
+    model,
+    sparse_autoencoder,
+    W_enc,
+    b_enc,
+    feature_ids: List[int],
+):
+    """
+    Returns the indices & values for the highest-activating tokens in the given batch of data.
+    """
+    with torch.no_grad():
+        # Get the post activations from the clean run
+        _, cache = model.run_with_cache(images)
+
+    inp = cache[sparse_autoencoder.cfg.hook_point]
+    b, seq_len, _ = inp.shape
+    post_reshaped = einops.rearrange(inp, "batch seq d_mlp -> (batch seq) d_mlp")
+
+    # Compute activations
+    sae_in = post_reshaped - sparse_autoencoder.b_dec
+    acts = einops.einsum(
+        sae_in,
+        W_enc,
+        "... d_in, d_in n -> ... n",
+    )
+    acts = acts + b_enc
+    acts = torch.nn.functional.relu(acts)
+
+    # Reshape acts to (batch, seq, n_features)
+    acts_reshaped = einops.rearrange(
+        acts, "(batch seq) n_features -> batch seq n_features", batch=b, seq=seq_len
+    )
+    temp_top_indices = {}
+    # # The matrix already only contains features due to the selective W_enc you passed in
+    # for idx, fid in enumerate(feature_ids): # Iterate through every feature id, and store the corresponding top images/tokens
+    #     # Get activations for this feature across all tokens and images
+    #     feature_acts = acts_reshaped[:, :, idx].flatten()
+
+    #     # Get top k activating tokens
+    #     top_acts_values, top_acts_indices = torch.sort(feature_acts, descending=True)
+
+    #     # Convert flat indices to (image_idx, token_idx) pairs
+    #     image_indices = top_acts_indices // seq_len
+    #     token_indices = top_acts_indices % seq_len
+
+    #     temp_top_indices[fid] = (list(zip(image_indices.tolist(), token_indices.tolist())), top_acts_values.tolist())
+
+    temp_top_indices = {}
+    for idx, fid in enumerate(feature_ids):
+        feature_acts = acts_reshaped[:, :, idx].flatten()
+        top_acts_values, top_acts_indices = torch.sort(feature_acts, descending=True)
+
+        image_indices = top_acts_indices // seq_len
+        token_indices = top_acts_indices % seq_len
+
+        temp_top_indices[fid] = {
+            "image_indices": image_indices.tolist(),
+            "token_indices": token_indices.tolist(),
+            "values": top_acts_values.tolist(),
+        }
+    return temp_top_indices
+
+
+torch.no_grad()
+
+
+def get_heatmap(
+    image: torch.Tensor,
+    model: HookedViT,
+    sparse_autoencoder: SparseAutoencoder,
+    feature_id: int,
+):
+    _, cache = model.run_with_cache(image.unsqueeze(0))
+
+    post_reshaped = einops.rearrange(
+        cache[sparse_autoencoder.cfg.hook_point], "batch seq d_mlp -> (batch seq) d_mlp"
+    )
+    # Compute activations (not from a fwd pass, but explicitly, by taking only the feature we want)
+    # This code is copied from the first part of the 'forward' method of the AutoEncoder class
+    sae_in = (
+        post_reshaped - sparse_autoencoder.b_dec
+    )  # Remove decoder bias as per Anthropic
+    acts = einops.einsum(
+        sae_in,
+        sparse_autoencoder.W_enc[:, feature_id],
+        "x d_in, d_in -> x",
+    )
+    return acts
+
+
+def image_patch_heatmap(activation_values, image_size=224, pixel_num=14):
+    activation_values = activation_values.detach().cpu().numpy()
+    activation_values = activation_values[1:]  # Remove CLS token
+    activation_values = activation_values.reshape(pixel_num, pixel_num)
+
+    # Create a heatmap overlay
+    heatmap = np.zeros((image_size, image_size))
+    patch_size = image_size // pixel_num
+
+    for i in range(pixel_num):
+        for j in range(pixel_num):
+            heatmap[
+                i * patch_size : (i + 1) * patch_size,
+                j * patch_size : (j + 1) * patch_size,
+            ] = activation_values[i, j]
+
+    return heatmap
+
+
+@torch.no_grad()
+def compute_neuron_activations(
+    images: torch.Tensor,
+    model: torch.nn.Module,
+    layer_name: str,
+    neuron_indices: List[int],
+    top_k: int = 10,
+) -> Dict[int, Tuple[torch.Tensor, torch.Tensor]]:
+    """
+    Compute the highest activating tokens for given neurons in a batch of images.
+
+    Args:
+        images: Input images
+        model: The main model
+        layer_name: Name of the layer to analyze
+        neuron_indices: List of neuron indices to analyze
+        top_k: Number of top activations to return per neuron
+
+    Returns:
+        Dictionary mapping neuron indices to tuples of (top_indices, top_values)
+    """
+    _, cache = model.run_with_cache(images, names_filter=[layer_name])
+
+    layer_activations = cache[layer_name]
+
+    batch_size, seq_len, n_neurons = layer_activations.shape
+
+    top_activations = {}
+    top_k = min(top_k, batch_size)
+
+    for neuron_idx in neuron_indices:
+        # Compute mean activation across sequence length
+        mean_activations = layer_activations[:, :, neuron_idx].mean(dim=1)
+        # Get top-k activations
+        top_values, top_indices = mean_activations.topk(top_k)
+        top_activations[neuron_idx] = (top_indices, top_values)
+
+    return top_activations
+
+
+# helper functions
+update_layout_set = {
+    "xaxis_range",
+    "yaxis_range",
+    "hovermode",
+    "xaxis_title",
+    "yaxis_title",
+    "colorbar",
+    "colorscale",
+    "coloraxis",
+    "title_x",
+    "bargap",
+    "bargroupgap",
+    "xaxis_tickformat",
+    "yaxis_tickformat",
+    "title_y",
+    "legend_title_text",
+    "xaxis_showgrid",
+    "xaxis_gridwidth",
+    "xaxis_gridcolor",
+    "yaxis_showgrid",
+    "yaxis_gridwidth",
+    "yaxis_gridcolor",
+    "showlegend",
+    "xaxis_tickmode",
+    "yaxis_tickmode",
+    "margin",
+    "xaxis_visible",
+    "yaxis_visible",
+    "bargap",
+    "bargroupgap",
+    "coloraxis_showscale",
+}
+
+
+def to_numpy(tensor):
+    """
+    Helper function to convert a tensor to a numpy array. Also works on lists, tuples, and numpy arrays.
+    """
+    if isinstance(tensor, np.ndarray):
+        return tensor
+    elif isinstance(tensor, (list, tuple)):
+        array = np.array(tensor)
+        return array
+    elif isinstance(tensor, (torch.Tensor, torch.nn.parameter.Parameter)):
+        return tensor.detach().cpu().numpy()
+    elif isinstance(tensor, (int, float, bool, str)):
+        return np.array(tensor)
+    else:
+        raise ValueError(f"Input to to_numpy has invalid type: {type(tensor)}")
+
+
+def wrap_text(text, width=60):
+    """Wrap text to a specified width."""
+    return "<br>".join(textwrap.wrap(text, width=width))
+
+
+def hist(cfg, tensor, save_name, show=False, to_wandb=False, renderer=None, **kwargs):
+    """ """
+    kwargs_post = {k: v for k, v in kwargs.items() if k in update_layout_set}
+    kwargs_pre = {k: v for k, v in kwargs.items() if k not in update_layout_set}
+    if "bargap" not in kwargs_post:
+        kwargs_post["bargap"] = 0.1
+    if "margin" in kwargs_post and isinstance(kwargs_post["margin"], int):
+        kwargs_post["margin"] = dict.fromkeys(list("tblr"), kwargs_post["margin"])
+
+    histogram_fig = px.histogram(x=to_numpy(tensor), **kwargs_pre)
+
+    # Handle the title separately
+    title = kwargs_post.pop("title", "")
+    wrapped_title = wrap_text(title, width=60)  # Adjust width as needed
+
+    # Update layout
+    histogram_fig.update_layout(
+        title={
+            "text": wrapped_title,
+            "font": {"size": 12},
+            "y": 0.98,  # Adjust as needed
+            "x": 0.5,
+            "xanchor": "center",
+            "yanchor": "top",
+        },
+        margin=dict(
+            t=120, b=50, l=50, r=50
+        ),  # Increased top margin for multi-line title
+        height=650,  # Increased height to accommodate wrapped title
+        **kwargs_post,
+    )
+
+    # save_path = os.path.join(cfg.save_figure_dir, f"{save_name}.png")
+
+    parent_dir = os.path.dirname(cfg.sae_path)
+    # Create a new folder path in sae_checkpoints/images with the original name
+    save_figure_dir = os.path.join(parent_dir, "sparsity_histograms")
+    # Ensure the directory exists
+    os.makedirs(save_figure_dir, exist_ok=True)
+
+    # Save the figure as a PNG file
+    # Save the figure as PNG and SVG files
+    base_path = os.path.join(save_figure_dir, save_name)
+    png_path = f"{base_path}.png"
+    svg_path = f"{base_path}.svg"
+
+    write_image(histogram_fig, png_path)
+    write_image(histogram_fig, svg_path)
+
+    # print(f"Histogram saved as PNG: {png_path}")
+    # print(f"Histogram saved as SVG: {svg_path}")
+
+    if show:
+        px.histogram(x=to_numpy(tensor), **kwargs_pre).update_layout(
+            **kwargs_post
+        ).show(renderer)
+    # close
+
+    if to_wandb:
+        wandb.log({"evaluation/feature_density": wandb.Histogram(to_numpy(tensor))})

--- a/src/vit_prisma/sae/evals/evaluator.py
+++ b/src/vit_prisma/sae/evals/evaluator.py
@@ -1,0 +1,635 @@
+import os
+from contextlib import contextmanager
+from dataclasses import fields
+from pathlib import Path
+from typing import Dict, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+import wandb
+from einops import einops
+from torch import nn
+from torch.utils.data import Dataset, DataLoader
+from tqdm import tqdm
+
+from vit_prisma.dataloaders.imagenet_dataset import get_imagenet_index_to_name
+from vit_prisma.models.base_vit import HookedViT
+from vit_prisma.sae.config import VisionModelSAERunnerConfig
+from vit_prisma.sae.evals.eval_utils import (
+    EvalStats,
+    get_recons_loss,
+    get_feature_probability,
+    get_text_embeddings,
+    get_text_labels,
+    calculate_log_frequencies,
+    visualize_sparsities,
+    get_intervals_for_sparsities,
+    highest_activating_tokens,
+    get_heatmap,
+    image_patch_heatmap,
+    compute_neuron_activations,
+)
+from vit_prisma.sae.sae import SparseAutoencoder
+from vit_prisma.sae.sae_utils import wandb_log_suffix
+from vit_prisma.utils.constants import EvaluationContext
+
+
+@contextmanager
+def eval_mode(sae: nn.Module):
+    """Context manager to temporarily switch to evaluation mode."""
+    is_train = sae.training
+    try:
+        sae.eval()
+        yield sae
+    finally:
+        if is_train:
+            sae.train()
+
+
+class Evaluator:
+    def __init__(
+        self,
+        model: HookedViT,
+        data: torch.utils.data.Dataset,
+        cfg: VisionModelSAERunnerConfig,
+        visualize_data: torch.utils.data.Dataset,
+    ):
+        """A class that holds various evaluations for SAEs trained on a given
+        model and dataset.
+        """
+        self.model = model
+        self.data = data
+        self.visualize_data = visualize_data
+        self.cfg = cfg
+        self._evaluation_cfg = None
+        self.neuron_indices = list(range(self.cfg.d_in))
+
+    @property
+    def evaluation_cfg(self):
+        return self._evaluation_cfg
+
+    @property
+    def dataloader(self):
+        return DataLoader(
+            self.data,
+            batch_size=self.evaluation_cfg.batch_size,
+            shuffle=False,
+            num_workers=0,
+        )
+
+    @evaluation_cfg.setter
+    def evaluation_cfg(self, context: EvaluationContext):
+        if context == EvaluationContext.TRAINING:
+            self._evaluation_cfg = self.cfg.training_eval
+        elif context == EvaluationContext.POST_TRAINING:
+            self._evaluation_cfg = self.cfg.post_training_eval
+        else:
+            raise ValueError(
+                "Invalid evaluation context (options are 'training' and "
+                "'post-training')"
+            )
+
+    def evaluate(
+        self,
+        sae: SparseAutoencoder,
+        context: EvaluationContext = EvaluationContext.TRAINING,
+    ):
+        """The type of evaluation is determined by the `context` parameter. All
+        evaluations functions specified in the `EvalConfig` are run.
+        """
+        self.evaluation_cfg = context
+        print(f"Performing {context.value} mode evaluation on SAE")
+
+        with eval_mode(sae):
+            stats = self.process_dataset(sae)
+            self.save_stats(sae, stats)
+
+            for func_name in self.evaluation_cfg.evaluation_functions:
+                print(f"Running the evaluation: {func_name.value}")
+                eval_func = getattr(self, func_name.value, None)
+                if eval_func:
+                    eval_func(sae, stats)
+                else:
+                    print(
+                        f"Warning: Evaluation function '{func_name.value}' not implemented"
+                    )
+
+    def process_dataset(self, sae):
+        """This function evaluates the performance of a sparse autoencoder on a dataset,
+        computing statistics such as L0 sparsity, reconstruction quality, and loss
+        metrics.
+
+        NB. Currently the function assumes the use of ImageNet dataset and a CLIP model.
+        """
+        all_l0 = []
+        all_l0_cls = []
+        all_l0_image = []
+
+        total_loss = 0
+        total_reconstruction_loss = 0
+        total_zero_abl_loss = 0
+        total_samples = 0
+        all_cosine_similarity = []
+
+        all_labels = get_text_labels("imagenet")
+        text_embeddings = get_text_embeddings(self.cfg.model_name, all_labels)
+
+        total_acts = None
+        total_tokens = 0
+
+        with torch.no_grad():
+            for batch_tokens, gt_labels, indices in self.dataloader:
+                batch_tokens = batch_tokens.to(self.cfg.device)
+                batch_size = batch_tokens.shape[0]
+
+                total_samples += batch_size
+
+                _, cache = self.model.run_with_cache(
+                    batch_tokens, names_filter=sae.cfg.hook_point
+                )
+                hook_point_activation = cache[sae.cfg.hook_point].to(self.cfg.device)
+
+                sae_out, feature_acts, loss, mse_loss, l1_loss, _, _ = sae(
+                    hook_point_activation
+                )
+
+                # Calculate feature probability
+                sae_activations = get_feature_probability(feature_acts)
+                if total_acts is None:
+                    total_acts = sae_activations.sum(0)
+                else:
+                    total_acts += sae_activations.sum(0)
+
+                total_tokens += sae_activations.shape[0]
+
+                # Get L0 stats per token
+                l0 = (feature_acts[:, 1:, :] > 0).float().sum(-1).detach()
+                all_l0.extend(l0.mean(dim=1).cpu().numpy())
+                l0_cls = (feature_acts[:, 0, :] > 0).float().sum(-1).detach()
+                all_l0_cls.extend(l0_cls.flatten().cpu().numpy())
+
+                # Get L0 stats per image
+                l0 = (feature_acts > 0).float().sum(-1).detach()
+                image_l0 = l0.sum(dim=1)  # Sum across all tokens
+                all_l0_image.extend(image_l0.cpu().numpy())
+
+                # Calculate cosine similarity between original activations and sae output
+                cos_sim = (
+                    torch.cosine_similarity(
+                        einops.rearrange(
+                            hook_point_activation,
+                            "batch seq d_mlp -> (batch seq) d_mlp",
+                        ),
+                        einops.rearrange(
+                            sae_out, "batch seq d_mlp -> (batch seq) d_mlp"
+                        ),
+                        dim=0,
+                    )
+                    .mean(-1)
+                    .tolist()
+                )
+                all_cosine_similarity.append(cos_sim)
+
+                # Calculate substitution loss
+                score, loss, recons_loss, zero_abl_loss = get_recons_loss(
+                    sae,
+                    self.model,
+                    batch_tokens,
+                    gt_labels,
+                    all_labels,
+                    text_embeddings,
+                    device=self.cfg.device,
+                )
+
+                total_loss += loss.item()
+                total_reconstruction_loss += recons_loss.item()
+                total_zero_abl_loss += zero_abl_loss.item()
+
+                if total_samples >= self.evaluation_cfg.max_evaluation_images:
+                    break
+
+        # Calculate average metrics
+        avg_loss = total_loss / total_samples
+        avg_reconstruction_loss = total_reconstruction_loss / total_samples
+        avg_zero_abl_loss = total_zero_abl_loss / total_samples
+
+        avg_l0 = np.mean(all_l0)
+        avg_l0_cls = np.mean(all_l0_cls)
+        avg_l0_image = np.mean(all_l0_image)
+
+        avg_cos_sim = np.mean(all_cosine_similarity)
+        log_frequencies_per_token = calculate_log_frequencies(
+            total_acts, total_tokens, self.cfg
+        )
+        log_frequencies_per_image = calculate_log_frequencies(
+            total_acts, total_samples, self.cfg
+        )
+
+        return EvalStats(
+            avg_loss,
+            avg_cos_sim,
+            avg_reconstruction_loss,
+            avg_zero_abl_loss,
+            avg_l0,
+            avg_l0_cls,
+            avg_l0_image,
+            log_frequencies_per_token,
+            log_frequencies_per_image,
+        )
+
+    def save_stats(self, sae: SparseAutoencoder, stats: EvalStats):
+        """Store the evaluation stats to wandb."""
+
+        print(f"Logging evaluation stats to wandb") if self.cfg.verbose else None
+        suffix = wandb_log_suffix(sae.cfg, self.cfg)
+
+        metrics = {
+            f"validation/{field.name}{suffix}": getattr(stats, field.name)
+            for field in fields(stats)
+        }
+        if self.cfg.log_to_wandb:
+            wandb.log(metrics)
+
+    def evaluate_sae_features(self, sae, stats: EvalStats):
+        """Plot and analyze log frequencies of feature activations for an SAE.
+
+        This function performs several tasks:
+            1. Visualises sparsity patterns across different activation frequency ranges.
+            2. Samples representative features from different activation frequency
+                intervals of interest.
+            3. Identifies top-activating images for sampled features.
+            4. Generates and saves visualizations of these top-activating images with
+                activation heatmaps.
+
+        NB:
+            - The function assumes the use of an ImageNet dataset.
+            - The function saves output images in a directory structure based on the
+                SAE checkpoint path.
+        """
+
+        print("Plotting log frequencies...")
+        log_freq_tokens = torch.Tensor(stats.log_frequencies_per_token)
+        log_freq_images = torch.Tensor(stats.log_frequencies_per_image)
+        intervals, conditions, conditions_texts = get_intervals_for_sparsities(
+            log_freq_tokens
+        )
+        visualize_sparsities(
+            self.cfg,
+            log_freq_tokens,
+            log_freq_images,
+            conditions,
+            conditions_texts,
+            "TOTAL",
+            sae,
+        )
+
+        print("Sampling features from pre-specified intervals...")
+        # get random features from different bins
+        interesting_features_indices = []
+        interesting_features_values = []
+        interesting_features_category = []
+        # number_features_per = 10
+        for condition, condition_text in zip(conditions, conditions_texts):
+            potential_indices = torch.nonzero(condition, as_tuple=True)[0]
+
+            # Shuffle these indices and select a subset
+            sampled_indices = potential_indices[
+                torch.randperm(len(potential_indices))[
+                    : self.evaluation_cfg.samples_per_bin
+                ]
+            ]
+
+            values = log_freq_tokens[sampled_indices]
+
+            interesting_features_indices = (
+                interesting_features_indices + sampled_indices.tolist()
+            )
+            interesting_features_values = interesting_features_values + values.tolist()
+            interesting_features_category = interesting_features_category + [
+                f"{condition_text}"
+            ] * len(sampled_indices)
+
+        print(set(interesting_features_category))
+
+        print("Running through dataset to get top images per feature...")
+        max_indices = {i: None for i in interesting_features_indices}
+        max_values = {i: None for i in interesting_features_indices}
+        b_enc = sae.b_enc[interesting_features_indices]
+        W_enc = sae.W_enc[:, interesting_features_indices]
+
+        for batch_idx, (total_images, total_labels, total_indices) in enumerate(
+            self.dataloader
+        ):
+            total_images = total_images.to(self.cfg.device)
+            total_indices = total_indices.to(self.cfg.device)
+
+            new_top_info = highest_activating_tokens(
+                total_images,
+                self.model,
+                sae,
+                W_enc,
+                b_enc,
+                interesting_features_indices,
+            )  # Return all
+
+            for feature_id in interesting_features_indices:
+                self._update_top_activations(
+                    feature_id,
+                    new_top_info[feature_id],
+                    total_indices,
+                    max_indices,
+                    max_values,
+                )
+
+            if (
+                batch_idx * self.evaluation_cfg.batch_size
+                >= self.evaluation_cfg.max_evaluation_images
+            ):
+                break
+
+        top_per_feature = {
+            i: (max_values[i].detach().cpu(), max_indices[i].detach().cpu())
+            for i in interesting_features_indices
+        }
+        self._plot_top_activating_images(
+            sae,
+            top_per_feature,
+            interesting_features_category,
+            interesting_features_indices,
+        )
+
+    def find_top_activations_for_neurons(
+        self,
+        sae: SparseAutoencoder,
+        stats: EvalStats,
+        top_k: int = 16,
+    ) -> Dict[int, Tuple[torch.Tensor, torch.Tensor]]:
+        max_samples = self.evaluation_cfg.max_evaluation_images
+
+        top_activations = {i: (None, None) for i in self.neuron_indices}
+
+        processed_samples = 0
+        for batch_images, _, batch_indices in self.dataloader:
+            batch_images = batch_images.to(self.cfg.device)
+            batch_indices = batch_indices.to(self.cfg.device)
+            batch_size = batch_images.shape[0]
+
+            batch_activations = compute_neuron_activations(
+                batch_images,
+                self.model,
+                self.cfg.hook_point,
+                self.neuron_indices,
+                top_k,
+            )
+
+            for neuron_idx in self.neuron_indices:
+                new_indices, new_values = batch_activations[neuron_idx]
+                new_indices = batch_indices[new_indices]
+
+                if top_activations[neuron_idx][0] is None:
+                    top_activations[neuron_idx] = (new_values, new_indices)
+                else:
+                    combined_values = torch.cat(
+                        (top_activations[neuron_idx][0], new_values)
+                    )
+                    combined_indices = torch.cat(
+                        (top_activations[neuron_idx][1], new_indices)
+                    )
+                    _, top_k_indices = torch.topk(combined_values, top_k)
+                    top_activations[neuron_idx] = (
+                        combined_values[top_k_indices],
+                        combined_indices[top_k_indices],
+                    )
+
+            processed_samples += batch_size
+            if processed_samples >= max_samples:
+                break
+
+        top_activations_per_neuron = {
+            i: (values.detach().cpu(), indices.detach().cpu())
+            for i, (values, indices) in top_activations.items()
+        }
+        self._visualize_top_activations(sae, top_activations_per_neuron)
+
+    def _visualize_top_activations(
+        self,
+        sae: SparseAutoencoder,
+        top_activations_per_neuron: int,
+    ):
+        ind_to_name = get_imagenet_index_to_name()
+        parent_dir = Path(self.cfg.sae_path).parent
+        folder = str(parent_dir / "max_images")
+        os.makedirs(folder, exist_ok=True)
+        print(f"Saving top activations images to {folder}")
+
+        for neuron_idx in tqdm(self.neuron_indices, total=len(self.neuron_indices)):
+            max_vals, max_inds = top_activations_per_neuron[neuron_idx]
+            images = []
+            model_images = []
+            gt_labels = []
+
+            for bid, v in zip(max_inds, max_vals):
+                image, label, image_ind = self.visualize_data[bid]
+                assert image_ind.item() == bid
+                images.append(image)
+
+                model_image, _, _ = self.data[bid]
+                model_images.append(model_image)
+                gt_labels.append(ind_to_name[str(label)][1])
+
+            grid_size = int(np.ceil(np.sqrt(len(images))))
+            fig, axs = plt.subplots(
+                int(np.ceil(len(images) / grid_size)), grid_size, figsize=(15, 15)
+            )
+            name = f"Layer: {self.cfg.hook_point}, Neuron: {neuron_idx}"
+            fig.suptitle(name)
+
+            for ax in axs.flatten():
+                ax.axis("off")
+
+            complete_bid = []
+
+            for i, (image_tensor, label, val, bid, model_img) in enumerate(
+                zip(images, gt_labels, max_vals, max_inds, model_images)
+            ):
+                image_tensor, model_img = image_tensor.to(
+                    self.cfg.device
+                ), model_img.to(self.cfg.device)
+
+                if bid in complete_bid:
+                    continue
+                complete_bid.append(bid)
+
+                row = i // grid_size
+                col = i % grid_size
+                heatmap = get_heatmap(model_img, self.model, sae, neuron_idx)
+                heatmap = image_patch_heatmap(
+                    heatmap,
+                    image_size=self.cfg.image_size,
+                    pixel_num=self.cfg.num_patch,
+                )
+
+                display = image_tensor.detach().cpu().numpy().transpose(1, 2, 0)
+
+                axs[row, col].imshow(display)
+                axs[row, col].imshow(
+                    heatmap, cmap="viridis", alpha=0.3
+                )  # Overlaying the heatmap
+                axs[row, col].set_title(f"{label} {val.item():0.03f}")
+                axs[row, col].axis("off")
+
+            plt.tight_layout()
+
+            plt.savefig(os.path.join(folder, f"neuron_{neuron_idx}.png"))
+            plt.close()
+
+    def _update_top_activations(
+        self,
+        feature_id: int,
+        feature_data: Dict,
+        total_indices: torch.Tensor,
+        max_indices: Dict[int, torch.Tensor],
+        max_values: Dict[int, torch.Tensor],
+    ):
+        batch_image_indices = torch.tensor(feature_data["image_indices"])
+        token_activation_values = torch.tensor(
+            feature_data["values"], device=self.cfg.device
+        )
+        global_image_indices = total_indices[batch_image_indices]  # Get global indices
+
+        # Get unique image indices and their highest activation values
+        unique_image_indices, unique_indices = torch.unique(
+            global_image_indices, return_inverse=True
+        )
+        unique_activation_values = torch.zeros_like(
+            unique_image_indices, dtype=torch.float, device=self.cfg.device
+        )
+        unique_activation_values.index_reduce_(
+            0, unique_indices, token_activation_values, "amax"
+        )
+
+        if max_indices[feature_id] is None:
+            max_indices[feature_id] = unique_image_indices
+            max_values[feature_id] = unique_activation_values
+        else:
+            # Concatenate with existing data
+            all_indices = torch.cat((max_indices[feature_id], unique_image_indices))
+            all_values = torch.cat((max_values[feature_id], unique_activation_values))
+
+            # Get unique indices again (in case of overlap between batches)
+            unique_all_indices, unique_all_idx = torch.unique(
+                all_indices, return_inverse=True
+            )
+            unique_all_values = torch.zeros_like(unique_all_indices, dtype=torch.float)
+            unique_all_values.index_reduce_(0, unique_all_idx, all_values, "amax")
+
+            # Select top k
+            if len(unique_all_indices) > self.evaluation_cfg.max_images_per_feature:
+                _, top_k_idx = torch.topk(
+                    unique_all_values,
+                    k=self.evaluation_cfg.max_images_per_feature,
+                )
+                max_indices[feature_id] = unique_all_indices[top_k_idx]
+                max_values[feature_id] = unique_all_values[top_k_idx]
+            else:
+                max_indices[feature_id] = unique_all_indices
+                max_values[feature_id] = unique_all_values
+
+    def _plot_top_activating_images(
+        self,
+        sae: SparseAutoencoder,
+        top_per_feature,
+        interesting_features_category,
+        interesting_features_values,
+    ):
+        # Create a new folder path in sae_checkpoints/images with the original name
+        output_dir = Path(self.cfg.sae_path).parent / "max_images"
+        os.makedirs(output_dir, exist_ok=True)
+        print(
+            f"Saving the images that represent the feature density of interest in the"
+            f" directory {output_dir}"
+        )
+
+        ind_to_name = get_imagenet_index_to_name()
+
+        for feature_ids, cat, logfreq in zip(
+            top_per_feature.keys(),
+            interesting_features_category,
+            interesting_features_values,
+        ):
+            max_vals, max_inds = top_per_feature[feature_ids]
+            images = []
+            model_images = []
+            gt_labels = []
+            unique_bids = set()
+            for bid, v in zip(max_inds, max_vals):
+                if len(unique_bids) >= self.evaluation_cfg.max_images_per_feature:
+                    break
+                if bid not in unique_bids:
+                    image, label, image_ind = self.visualize_data[bid]
+                    images.append(image)
+                    model_img, _, _ = self.data[bid]
+                    model_images.append(model_img)
+                    gt_labels.append(ind_to_name[str(label)][1])
+                    unique_bids.add(bid)
+
+            grid_size = int(np.ceil(np.sqrt(len(images))))
+            fig, axs = plt.subplots(
+                int(np.ceil(len(images) / grid_size)), grid_size, figsize=(15, 15)
+            )
+            name = f"Category: {cat},  Feature: {feature_ids}"
+            fig.suptitle(name)  # , y=0.95)
+            for ax in axs.flatten():
+                ax.axis("off")
+            complete_bid = []
+
+            for i, (image_tensor, label, val, bid, model_img) in enumerate(
+                zip(images, gt_labels, max_vals, max_inds, model_images)
+            ):
+                image_tensor, model_img = image_tensor.to(
+                    self.cfg.device
+                ), model_img.to(self.cfg.device)
+
+                if bid in complete_bid:
+                    continue
+                complete_bid.append(bid)
+
+                row = i // grid_size
+                col = i % grid_size
+
+                heatmap = get_heatmap(model_img, self.model, sae, feature_ids)
+                heatmap = image_patch_heatmap(
+                    heatmap,
+                    image_size=self.cfg.image_size,
+                    pixel_num=self.cfg.num_patch,
+                )
+                display = image_tensor.detach().cpu().numpy().transpose(1, 2, 0)
+
+                has_zero = False
+
+                axs[row, col].imshow(display)
+                axs[row, col].imshow(
+                    heatmap, cmap="viridis", alpha=0.3
+                )  # Overlaying the heatmap
+                axs[row, col].set_title(
+                    f"{label} {val.item():0.06f} {'class token!' if has_zero else ''}"
+                )
+                axs[row, col].axis("off")
+
+            plt.tight_layout()
+
+            folder = os.path.join(output_dir, f"{cat}")
+            os.makedirs(folder, exist_ok=True)
+            plt.savefig(
+                os.path.join(
+                    folder, f"neglogfreq_{-logfreq}_feature_id:{feature_ids}.png"
+                )
+            )
+            # save svg
+            plt.savefig(
+                os.path.join(
+                    folder, f"neglogfreq_{-logfreq}_feature_id:{feature_ids}.svg"
+                )
+            )
+            plt.close()

--- a/src/vit_prisma/utils/constants.py
+++ b/src/vit_prisma/utils/constants.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class Evaluation(Enum):
+    """Enum that maps to the possible evaluation functions"""
+
+    FEATURE_BASIS_EVAL = "evaluate_sae_features"
+    NEURON_BASIS_EVAL = "find_top_activations_for_neurons"
+
+
+class EvaluationContext(Enum):
+
+    TRAINING = "train"
+    POST_TRAINING = "post-train"


### PR DESCRIPTION
I have moved the evaluation code into an `Evaluator` class. The idea here was that this would be easier to extend and also that there are two different evaluation contexts, `TrainingEval` and `PostTrainingEval`. This was done so that a cheaper form of evaluation can be done during training, such that one can get an idea of training but one would want to perform a full evaluation on a model that is already trained.

* I've split evals.py into evaluator.py and eval_utils.py. I haven't changed the evaluation code itself.
* Specific evaluations can be ran by adding them to the `EvalConfig`

