### PR TITLE
Config refactor and logging changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+data
+
 # Other repos
 beta-tcvae
 disent

--- a/src/vit_prisma/prisma_tools/loading_from_pretrained.py
+++ b/src/vit_prisma/prisma_tools/loading_from_pretrained.py
@@ -7,6 +7,7 @@ Copyright (c) Sonia Joseph. All rights reserved.
 Inspired by TransformerLens. Some functions have been adapted from the TransformerLens project.
 For more information on TransformerLens, visit: https://github.com/neelnanda-io/TransformerLens
 """
+
 import logging
 from functools import partial
 from typing import Dict
@@ -16,14 +17,23 @@ import einops
 import timm
 import torch
 from tokenizers.models import Model
-from transformers import AutoConfig, ViTForImageClassification, VivitForVideoClassification, CLIPModel, ViTModel
+from transformers import (
+    AutoConfig,
+    ViTForImageClassification,
+    VivitForVideoClassification,
+    CLIPModel,
+    ViTModel,
+)
 from vit_prisma.configs.HookedTextTransformerConfig import HookedTextTransformerConfig
 from vit_prisma.configs.HookedViTConfig import HookedViTConfig
 from vit_prisma.utils.enums import ModelType
 
 try:
     from huggingface_hub import hf_hub_download
-    hf_hub_download = partial(hf_hub_download, library_name="open_clip", library_version='2.20.0')
+
+    hf_hub_download = partial(
+        hf_hub_download, library_name="open_clip", library_version="2.20.0"
+    )
     _has_hf_hub = True
 except ImportError:
     hf_hub_download = None
@@ -33,57 +43,89 @@ import json
 
 
 def convert_kandinsky_clip_weights(
-        old_state_dict,
-        cfg: HookedViTConfig,
-        device = 'cuda',
+    old_state_dict,
+    cfg: HookedViTConfig,
+    device="cuda",
 ):
     new_vision_model_state_dict = {}
 
-    print("Convering Kandinsky Clip weights")
+    logging.info("Convering Kandinsky Clip weights")
 
     # Convert embedding layers
-    new_vision_model_state_dict["cls_token"] = old_state_dict["vision_model.embeddings.class_embedding"].unsqueeze(0).unsqueeze(0)
-    new_vision_model_state_dict["pos_embed.W_pos"] = old_state_dict["vision_model.embeddings.position_embedding.weight"]
-    
+    new_vision_model_state_dict["cls_token"] = (
+        old_state_dict["vision_model.embeddings.class_embedding"]
+        .unsqueeze(0)
+        .unsqueeze(0)
+    )
+    new_vision_model_state_dict["pos_embed.W_pos"] = old_state_dict[
+        "vision_model.embeddings.position_embedding.weight"
+    ]
+
     # Patch embedding
-    new_vision_model_state_dict["embed.proj.weight"] = old_state_dict["vision_model.embeddings.patch_embedding.weight"]
+    new_vision_model_state_dict["embed.proj.weight"] = old_state_dict[
+        "vision_model.embeddings.patch_embedding.weight"
+    ]
     new_vision_model_state_dict["embed.proj.bias"] = torch.zeros((cfg.d_model,))
 
     # Convert layer norms
-    new_vision_model_state_dict["ln_final.w"] = old_state_dict["vision_model.post_layernorm.weight"]
-    new_vision_model_state_dict["ln_final.b"] = old_state_dict["vision_model.post_layernorm.bias"]
+    new_vision_model_state_dict["ln_final.w"] = old_state_dict[
+        "vision_model.post_layernorm.weight"
+    ]
+    new_vision_model_state_dict["ln_final.b"] = old_state_dict[
+        "vision_model.post_layernorm.bias"
+    ]
 
-    new_vision_model_state_dict["ln_pre.w"] = old_state_dict["vision_model.pre_layrnorm.weight"]
-    new_vision_model_state_dict["ln_pre.b"] = old_state_dict["vision_model.pre_layrnorm.bias"]
+    new_vision_model_state_dict["ln_pre.w"] = old_state_dict[
+        "vision_model.pre_layrnorm.weight"
+    ]
+    new_vision_model_state_dict["ln_pre.b"] = old_state_dict[
+        "vision_model.pre_layrnorm.bias"
+    ]
 
-    print("visual projection shape", old_state_dict["visual_projection.weight"].shape)
+    logging.info(
+        "visual projection shape", old_state_dict["visual_projection.weight"].shape
+    )
 
     # Convert transformer blocks
-    print("doing number of layers", cfg.n_layers)
+    logging.info("doing number of layers", cfg.n_layers)
     for layer in range(cfg.n_layers):
         old_layer_key = f"vision_model.encoder.layers.{layer}"
         new_layer_key = f"blocks.{layer}"
 
         # Layer norms
-        new_vision_model_state_dict[f"{new_layer_key}.ln1.w"] = old_state_dict[f"{old_layer_key}.layer_norm1.weight"]
-        new_vision_model_state_dict[f"{new_layer_key}.ln1.b"] = old_state_dict[f"{old_layer_key}.layer_norm1.bias"]
-        new_vision_model_state_dict[f"{new_layer_key}.ln2.w"] = old_state_dict[f"{old_layer_key}.layer_norm2.weight"]
-        new_vision_model_state_dict[f"{new_layer_key}.ln2.b"] = old_state_dict[f"{old_layer_key}.layer_norm2.bias"]
+        new_vision_model_state_dict[f"{new_layer_key}.ln1.w"] = old_state_dict[
+            f"{old_layer_key}.layer_norm1.weight"
+        ]
+        new_vision_model_state_dict[f"{new_layer_key}.ln1.b"] = old_state_dict[
+            f"{old_layer_key}.layer_norm1.bias"
+        ]
+        new_vision_model_state_dict[f"{new_layer_key}.ln2.w"] = old_state_dict[
+            f"{old_layer_key}.layer_norm2.weight"
+        ]
+        new_vision_model_state_dict[f"{new_layer_key}.ln2.b"] = old_state_dict[
+            f"{old_layer_key}.layer_norm2.bias"
+        ]
 
         # Attention weights
         W_Q = old_state_dict[f"{old_layer_key}.self_attn.q_proj.weight"]
-        W_K = old_state_dict[f"{old_layer_key}.self_attn.k_proj.weight"] 
+        W_K = old_state_dict[f"{old_layer_key}.self_attn.k_proj.weight"]
         W_V = old_state_dict[f"{old_layer_key}.self_attn.v_proj.weight"]
-        
+
         b_Q = old_state_dict[f"{old_layer_key}.self_attn.q_proj.bias"]
         b_K = old_state_dict[f"{old_layer_key}.self_attn.k_proj.bias"]
         b_V = old_state_dict[f"{old_layer_key}.self_attn.v_proj.bias"]
 
         # Reshape Q, K, V weights
-        W_Q = einops.rearrange(W_Q, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
-        W_K = einops.rearrange(W_K, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
-        W_V = einops.rearrange(W_V, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
-        
+        W_Q = einops.rearrange(
+            W_Q, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
+        W_K = einops.rearrange(
+            W_K, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
+        W_V = einops.rearrange(
+            W_V, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
+
         # Reshape Q, K, V biases
         b_Q = einops.rearrange(b_Q, "(h dh) -> h dh", h=cfg.n_heads, dh=cfg.d_head)
         b_K = einops.rearrange(b_K, "(h dh) -> h dh", h=cfg.n_heads, dh=cfg.d_head)
@@ -92,7 +134,9 @@ def convert_kandinsky_clip_weights(
         # Output projection
         W_O = old_state_dict[f"{old_layer_key}.self_attn.out_proj.weight"]
         b_O = old_state_dict[f"{old_layer_key}.self_attn.out_proj.bias"]
-        W_O = einops.rearrange(W_O, "d (h dh) -> h dh d", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
+        W_O = einops.rearrange(
+            W_O, "d (h dh) -> h dh d", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
 
         new_vision_model_state_dict[f"{new_layer_key}.attn.W_Q"] = W_Q
         new_vision_model_state_dict[f"{new_layer_key}.attn.W_K"] = W_K
@@ -118,7 +162,9 @@ def convert_kandinsky_clip_weights(
         new_vision_model_state_dict[f"{new_layer_key}.mlp.b_out"] = mlp_b_out
 
     # Set final projection
-    new_vision_model_state_dict["head.W_H"] = old_state_dict['visual_projection.weight'].T
+    new_vision_model_state_dict["head.W_H"] = old_state_dict[
+        "visual_projection.weight"
+    ].T
     new_vision_model_state_dict["head.b_H"] = torch.zeros((cfg.n_classes,))
 
     return new_vision_model_state_dict
@@ -132,10 +178,16 @@ def convert_open_clip_weights(
     new_vision_model_state_dict = {}
 
     # Convert embedding layers
-    new_vision_model_state_dict["cls_token"] = old_state_dict["visual.class_embedding"].unsqueeze(0).unsqueeze(0)
-    new_vision_model_state_dict["pos_embed.W_pos"] = old_state_dict["visual.positional_embedding"].clone()
+    new_vision_model_state_dict["cls_token"] = (
+        old_state_dict["visual.class_embedding"].unsqueeze(0).unsqueeze(0)
+    )
+    new_vision_model_state_dict["pos_embed.W_pos"] = old_state_dict[
+        "visual.positional_embedding"
+    ].clone()
 
-    new_vision_model_state_dict["embed.proj.weight"] = old_state_dict["visual.conv1.weight"]
+    new_vision_model_state_dict["embed.proj.weight"] = old_state_dict[
+        "visual.conv1.weight"
+    ]
     new_vision_model_state_dict["embed.proj.bias"] = torch.zeros((cfg.d_model,))
 
     # Convert layer norms
@@ -145,13 +197,15 @@ def convert_open_clip_weights(
     new_vision_model_state_dict["ln_pre.w"] = old_state_dict["visual.ln_pre.weight"]
     new_vision_model_state_dict["ln_pre.b"] = old_state_dict["visual.ln_pre.bias"]
 
-    print("visual projection shape", old_state_dict["visual.proj"].shape)
+    logging.info("visual projection shape", old_state_dict["visual.proj"].shape)
 
-    new_vision_model_state_dict["head.W_H"] = old_state_dict['visual.proj']
+    new_vision_model_state_dict["head.W_H"] = old_state_dict["visual.proj"]
     new_vision_model_state_dict["head.b_H"] = torch.zeros((cfg.n_classes,))
 
     old_layer_key = f"visual.transformer.resblocks"
-    new_vision_model_state_dict.update(_load_open_clip_attention_weights(old_state_dict, cfg, old_layer_key))
+    new_vision_model_state_dict.update(
+        _load_open_clip_attention_weights(old_state_dict, cfg, old_layer_key)
+    )
 
     return new_vision_model_state_dict
 
@@ -165,7 +219,9 @@ def convert_open_clip_text_weights(
     new_text_model_state_dict = {}
 
     # Convert embedding layers
-    new_text_model_state_dict["token_embed.weight"] = old_state_dict["token_embedding.weight"]
+    new_text_model_state_dict["token_embed.weight"] = old_state_dict[
+        "token_embedding.weight"
+    ]
     new_text_model_state_dict["pos_embed"] = old_state_dict["positional_embedding"]
 
     new_text_model_state_dict["ln_final.w"] = old_state_dict["ln_final.weight"]
@@ -176,7 +232,9 @@ def convert_open_clip_text_weights(
     new_text_model_state_dict["head.b_H"] = torch.zeros((cfg.n_classes,))
 
     old_layer_key = f"transformer.resblocks"
-    new_text_model_state_dict.update(_load_open_clip_attention_weights(old_state_dict, cfg, old_layer_key))
+    new_text_model_state_dict.update(
+        _load_open_clip_attention_weights(old_state_dict, cfg, old_layer_key)
+    )
 
     return new_text_model_state_dict
 
@@ -198,10 +256,18 @@ def _load_open_clip_attention_weights(
         old_layer_key = f"{layer_key}.{layer}"
 
         # Layer norms
-        new_state_dict[f"{new_layer_key}.ln1.w"] = old_state_dict[f"{old_layer_key}.ln_1.weight"]
-        new_state_dict[f"{new_layer_key}.ln1.b"] = old_state_dict[f"{old_layer_key}.ln_1.bias"]
-        new_state_dict[f"{new_layer_key}.ln2.w"] = old_state_dict[f"{old_layer_key}.ln_2.weight"]
-        new_state_dict[f"{new_layer_key}.ln2.b"] = old_state_dict[f"{old_layer_key}.ln_2.bias"]
+        new_state_dict[f"{new_layer_key}.ln1.w"] = old_state_dict[
+            f"{old_layer_key}.ln_1.weight"
+        ]
+        new_state_dict[f"{new_layer_key}.ln1.b"] = old_state_dict[
+            f"{old_layer_key}.ln_1.bias"
+        ]
+        new_state_dict[f"{new_layer_key}.ln2.w"] = old_state_dict[
+            f"{old_layer_key}.ln_2.weight"
+        ]
+        new_state_dict[f"{new_layer_key}.ln2.b"] = old_state_dict[
+            f"{old_layer_key}.ln_2.bias"
+        ]
 
         # Attention weights
         in_proj_weight = old_state_dict[f"{old_layer_key}.attn.in_proj_weight"]
@@ -212,9 +278,15 @@ def _load_open_clip_attention_weights(
         b_Q, b_K, b_V = in_proj_bias.chunk(3)
 
         # Reshape Q, K, V weights
-        W_Q = einops.rearrange(W_Q, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
-        W_K = einops.rearrange(W_K, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
-        W_V = einops.rearrange(W_V, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
+        W_Q = einops.rearrange(
+            W_Q, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
+        W_K = einops.rearrange(
+            W_K, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
+        W_V = einops.rearrange(
+            W_V, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
 
         # Reshape Q, K, V biases
         b_Q = einops.rearrange(b_Q, "(h dh) -> h dh", h=cfg.n_heads, dh=cfg.d_head)
@@ -224,7 +296,9 @@ def _load_open_clip_attention_weights(
         # Output projection
         W_O = old_state_dict[f"{old_layer_key}.attn.out_proj.weight"]
         b_O = old_state_dict[f"{old_layer_key}.attn.out_proj.bias"]
-        W_O = einops.rearrange(W_O, "d (h dh) -> h dh d", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
+        W_O = einops.rearrange(
+            W_O, "d (h dh) -> h dh d", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
 
         new_state_dict[f"{new_layer_key}.attn.W_Q"] = W_Q
         new_state_dict[f"{new_layer_key}.attn.W_K"] = W_K
@@ -253,37 +327,59 @@ def _load_open_clip_attention_weights(
 
 
 def convert_dino_weights(
-        old_state_dict,
-        cfg: HookedViTConfig,
+    old_state_dict,
+    cfg: HookedViTConfig,
 ):
-    
+
     new_state_dict = {}
 
     new_state_dict["cls_token"] = old_state_dict["embeddings.cls_token"]
-    new_state_dict["pos_embed.W_pos"] = old_state_dict["embeddings.position_embeddings"].squeeze(0)
-    new_state_dict["embed.proj.weight"] = old_state_dict["embeddings.patch_embeddings.projection.weight"]
-    new_state_dict["embed.proj.bias"] = old_state_dict["embeddings.patch_embeddings.projection.bias"]
+    new_state_dict["pos_embed.W_pos"] = old_state_dict[
+        "embeddings.position_embeddings"
+    ].squeeze(0)
+    new_state_dict["embed.proj.weight"] = old_state_dict[
+        "embeddings.patch_embeddings.projection.weight"
+    ]
+    new_state_dict["embed.proj.bias"] = old_state_dict[
+        "embeddings.patch_embeddings.projection.bias"
+    ]
     new_state_dict["ln_final.w"] = old_state_dict["layernorm.weight"]
     new_state_dict["ln_final.b"] = old_state_dict["layernorm.bias"]
 
     for layer in range(cfg.n_layers):
         layer_key = f"encoder.layer.{layer}"
         new_layer_key = f"blocks.{layer}"
-        new_state_dict[f"{new_layer_key}.ln1.w"] = old_state_dict[f"{layer_key}.layernorm_before.weight"]
-        new_state_dict[f"{new_layer_key}.ln1.b"] = old_state_dict[f"{layer_key}.layernorm_before.bias"]
-        new_state_dict[f"{new_layer_key}.ln2.w"] = old_state_dict[f"{layer_key}.layernorm_after.weight"]
-        new_state_dict[f"{new_layer_key}.ln2.b"] = old_state_dict[f"{layer_key}.layernorm_after.bias"]
+        new_state_dict[f"{new_layer_key}.ln1.w"] = old_state_dict[
+            f"{layer_key}.layernorm_before.weight"
+        ]
+        new_state_dict[f"{new_layer_key}.ln1.b"] = old_state_dict[
+            f"{layer_key}.layernorm_before.bias"
+        ]
+        new_state_dict[f"{new_layer_key}.ln2.w"] = old_state_dict[
+            f"{layer_key}.layernorm_after.weight"
+        ]
+        new_state_dict[f"{new_layer_key}.ln2.b"] = old_state_dict[
+            f"{layer_key}.layernorm_after.bias"
+        ]
 
         W_Q = old_state_dict[f"{layer_key}.attention.attention.query.weight"]
         W_K = old_state_dict[f"{layer_key}.attention.attention.key.weight"]
         W_V = old_state_dict[f"{layer_key}.attention.attention.value.weight"]
         W_O = old_state_dict[f"{layer_key}.attention.output.dense.weight"]
 
-        W_Q = einops.rearrange(W_Q, "(h dh) d-> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
-        W_K = einops.rearrange(W_K, "(h dh) d-> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
-        W_V = einops.rearrange(W_V, "(h dh) d-> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
-        W_O = einops.rearrange(W_O, "d (h dh) -> h dh d", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
-        
+        W_Q = einops.rearrange(
+            W_Q, "(h dh) d-> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
+        W_K = einops.rearrange(
+            W_K, "(h dh) d-> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
+        W_V = einops.rearrange(
+            W_V, "(h dh) d-> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
+        W_O = einops.rearrange(
+            W_O, "d (h dh) -> h dh d", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
+
         new_state_dict[f"{new_layer_key}.attn.W_Q"] = W_Q
         new_state_dict[f"{new_layer_key}.attn.W_K"] = W_K
         new_state_dict[f"{new_layer_key}.attn.W_V"] = W_V
@@ -320,42 +416,67 @@ def convert_dino_weights(
 
 
 def convert_clip_weights(
-        old_state_dict,
-        old_head_state_dict,
-        cfg: HookedViTConfig,
+    old_state_dict,
+    old_head_state_dict,
+    cfg: HookedViTConfig,
 ):
-    
+
     new_vision_model_state_dict = {}
 
-    new_vision_model_state_dict["cls_token"] = old_state_dict["embeddings.class_embedding"].unsqueeze(0).unsqueeze(0)
-    new_vision_model_state_dict["pos_embed.W_pos"] = old_state_dict["embeddings.position_embedding.weight"]
-    new_vision_model_state_dict["embed.proj.weight"] = old_state_dict["embeddings.patch_embedding.weight"]
-    new_vision_model_state_dict["embed.proj.bias"] =  torch.zeros((cfg.d_model,), device=new_vision_model_state_dict["embed.proj.weight"].device)
+    new_vision_model_state_dict["cls_token"] = (
+        old_state_dict["embeddings.class_embedding"].unsqueeze(0).unsqueeze(0)
+    )
+    new_vision_model_state_dict["pos_embed.W_pos"] = old_state_dict[
+        "embeddings.position_embedding.weight"
+    ]
+    new_vision_model_state_dict["embed.proj.weight"] = old_state_dict[
+        "embeddings.patch_embedding.weight"
+    ]
+    new_vision_model_state_dict["embed.proj.bias"] = torch.zeros(
+        (cfg.d_model,), device=new_vision_model_state_dict["embed.proj.weight"].device
+    )
     new_vision_model_state_dict["ln_final.w"] = old_state_dict["post_layernorm.weight"]
     new_vision_model_state_dict["ln_final.b"] = old_state_dict["post_layernorm.bias"]
-    new_vision_model_state_dict["ln_pre.w"] = old_state_dict["pre_layrnorm.weight"] #typo in ClipModel
+    new_vision_model_state_dict["ln_pre.w"] = old_state_dict[
+        "pre_layrnorm.weight"
+    ]  # typo in ClipModel
     new_vision_model_state_dict["ln_pre.b"] = old_state_dict["pre_layrnorm.bias"]
-
 
     for layer in range(cfg.n_layers):
         layer_key = f"encoder.layers.{layer}"
         new_layer_key = f"blocks.{layer}"
 
-        new_vision_model_state_dict[f"{new_layer_key}.ln1.w"] = old_state_dict[f"{layer_key}.layer_norm1.weight"]
-        new_vision_model_state_dict[f"{new_layer_key}.ln1.b"] = old_state_dict[f"{layer_key}.layer_norm1.bias"]
-        new_vision_model_state_dict[f"{new_layer_key}.ln2.w"] = old_state_dict[f"{layer_key}.layer_norm2.weight"]
-        new_vision_model_state_dict[f"{new_layer_key}.ln2.b"] = old_state_dict[f"{layer_key}.layer_norm2.bias"]
+        new_vision_model_state_dict[f"{new_layer_key}.ln1.w"] = old_state_dict[
+            f"{layer_key}.layer_norm1.weight"
+        ]
+        new_vision_model_state_dict[f"{new_layer_key}.ln1.b"] = old_state_dict[
+            f"{layer_key}.layer_norm1.bias"
+        ]
+        new_vision_model_state_dict[f"{new_layer_key}.ln2.w"] = old_state_dict[
+            f"{layer_key}.layer_norm2.weight"
+        ]
+        new_vision_model_state_dict[f"{new_layer_key}.ln2.b"] = old_state_dict[
+            f"{layer_key}.layer_norm2.bias"
+        ]
 
         W_Q = old_state_dict[f"{layer_key}.self_attn.q_proj.weight"]
         W_K = old_state_dict[f"{layer_key}.self_attn.k_proj.weight"]
         W_V = old_state_dict[f"{layer_key}.self_attn.v_proj.weight"]
         W_O = old_state_dict[f"{layer_key}.self_attn.out_proj.weight"]
 
-        W_Q = einops.rearrange(W_Q, "(h dh) d-> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
-        W_K = einops.rearrange(W_K, "(h dh) d-> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
-        W_V = einops.rearrange(W_V, "(h dh) d-> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
-        W_O = einops.rearrange(W_O, "d (h dh) -> h dh d", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
-        
+        W_Q = einops.rearrange(
+            W_Q, "(h dh) d-> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
+        W_K = einops.rearrange(
+            W_K, "(h dh) d-> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
+        W_V = einops.rearrange(
+            W_V, "(h dh) d-> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
+        W_O = einops.rearrange(
+            W_O, "d (h dh) -> h dh d", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
+
         new_vision_model_state_dict[f"{new_layer_key}.attn.W_Q"] = W_Q
         new_vision_model_state_dict[f"{new_layer_key}.attn.W_K"] = W_K
         new_vision_model_state_dict[f"{new_layer_key}.attn.W_V"] = W_V
@@ -388,36 +509,49 @@ def convert_clip_weights(
         new_vision_model_state_dict[f"{new_layer_key}.mlp.b_in"] = mlp_b_in
         new_vision_model_state_dict[f"{new_layer_key}.mlp.b_out"] = mlp_b_out
 
+    new_vision_model_state_dict["head.W_H"] = einops.rearrange(
+        old_head_state_dict["weight"], "c d -> d c"
+    )
+    new_vision_model_state_dict["head.b_H"] = torch.zeros(
+        (cfg.n_classes,), device=new_vision_model_state_dict["head.W_H"].device
+    )
 
-    new_vision_model_state_dict["head.W_H"] = einops.rearrange(old_head_state_dict["weight"], "c d -> d c")
-    new_vision_model_state_dict["head.b_H"] = torch.zeros((cfg.n_classes,), device=new_vision_model_state_dict["head.W_H"].device)
-
-        
     return new_vision_model_state_dict
 
 
 def convert_timm_weights(
-        old_state_dict,
-        cfg: HookedViTConfig,
+    old_state_dict,
+    cfg: HookedViTConfig,
 ):
 
     new_state_dict = {}
     new_state_dict["cls_token"] = old_state_dict["cls_token"]
     new_state_dict["pos_embed.W_pos"] = old_state_dict["pos_embed"].squeeze(0)
     new_state_dict["embed.proj.weight"] = old_state_dict["patch_embed.proj.weight"]
-    new_state_dict["embed.proj.bias"] = old_state_dict["patch_embed.proj.bias"] 
+    new_state_dict["embed.proj.bias"] = old_state_dict["patch_embed.proj.bias"]
     new_state_dict["ln_final.w"] = old_state_dict["norm.weight"]
     new_state_dict["ln_final.b"] = old_state_dict["norm.bias"]
 
     for layer in range(cfg.n_layers):
-        layer_key = f"blocks.{layer}" 
-        new_state_dict[f"{layer_key}.ln1.w"] = old_state_dict[f"{layer_key}.norm1.weight"]
+        layer_key = f"blocks.{layer}"
+        new_state_dict[f"{layer_key}.ln1.w"] = old_state_dict[
+            f"{layer_key}.norm1.weight"
+        ]
         new_state_dict[f"{layer_key}.ln1.b"] = old_state_dict[f"{layer_key}.norm1.bias"]
-        new_state_dict[f"{layer_key}.ln2.w"] = old_state_dict[f"{layer_key}.norm2.weight"]
+        new_state_dict[f"{layer_key}.ln2.w"] = old_state_dict[
+            f"{layer_key}.norm2.weight"
+        ]
         new_state_dict[f"{layer_key}.ln2.b"] = old_state_dict[f"{layer_key}.norm2.bias"]
 
         W = old_state_dict[f"{layer_key}.attn.qkv.weight"]
-        W_reshape = einops.rearrange( W, "(three h dh) d ->three h d dh" , three=3, h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
+        W_reshape = einops.rearrange(
+            W,
+            "(three h dh) d ->three h d dh",
+            three=3,
+            h=cfg.n_heads,
+            d=cfg.d_model,
+            dh=cfg.d_head,
+        )
         W_Q, W_K, W_V = torch.unbind(W_reshape, dim=0)
         new_state_dict[f"{layer_key}.attn.W_Q"] = W_Q
         new_state_dict[f"{layer_key}.attn.W_K"] = W_K
@@ -428,7 +562,13 @@ def convert_timm_weights(
         new_state_dict[f"{layer_key}.attn.W_O"] = W_O
 
         attn_bias = old_state_dict[f"{layer_key}.attn.qkv.bias"]
-        attn_bias_reshape = einops.rearrange(attn_bias, "(three h dh) -> three h dh", three=3, h=cfg.n_heads, dh=cfg.d_head)
+        attn_bias_reshape = einops.rearrange(
+            attn_bias,
+            "(three h dh) -> three h dh",
+            three=3,
+            h=cfg.n_heads,
+            dh=cfg.d_head,
+        )
         b_Q, b_K, b_V = torch.unbind(attn_bias_reshape, dim=0)
         new_state_dict[f"{layer_key}.attn.b_Q"] = b_Q
         new_state_dict[f"{layer_key}.attn.b_K"] = b_K
@@ -437,8 +577,12 @@ def convert_timm_weights(
         b_O = old_state_dict[f"{layer_key}.attn.proj.bias"]
         new_state_dict[f"{layer_key}.attn.b_O"] = b_O
 
-        new_state_dict[f"{layer_key}.mlp.b_in"] = old_state_dict[f"{layer_key}.mlp.fc1.bias"]
-        new_state_dict[f"{layer_key}.mlp.b_out"] = old_state_dict[f"{layer_key}.mlp.fc2.bias"]
+        new_state_dict[f"{layer_key}.mlp.b_in"] = old_state_dict[
+            f"{layer_key}.mlp.fc1.bias"
+        ]
+        new_state_dict[f"{layer_key}.mlp.b_out"] = old_state_dict[
+            f"{layer_key}.mlp.fc2.bias"
+        ]
 
         mlp_W_in = old_state_dict[f"{layer_key}.mlp.fc1.weight"]
         mlp_W_in = einops.rearrange(mlp_W_in, "m d -> d m")
@@ -448,165 +592,238 @@ def convert_timm_weights(
         mlp_W_out = einops.rearrange(mlp_W_out, "d m -> m d")
         new_state_dict[f"{layer_key}.mlp.W_out"] = mlp_W_out
 
-
-    new_state_dict["head.W_H"] = einops.rearrange(old_state_dict["head.weight"], "c d -> d c")
+    new_state_dict["head.W_H"] = einops.rearrange(
+        old_state_dict["head.weight"], "c d -> d c"
+    )
     new_state_dict["head.b_H"] = old_state_dict["head.bias"]
-
 
     return new_state_dict
 
 
 def convert_vivet_weights(
-        old_state_dict,
-        cfg: HookedViTConfig,
+    old_state_dict,
+    cfg: HookedViTConfig,
 ):
 
     new_state_dict = {}
 
     new_state_dict["cls_token"] = old_state_dict["vivit.embeddings.cls_token"]
-    new_state_dict["pos_embed.W_pos"] = old_state_dict["vivit.embeddings.position_embeddings"].squeeze(0)
-    new_state_dict["embed.proj.weight"] = old_state_dict["vivit.embeddings.patch_embeddings.projection.weight"]
-    new_state_dict["embed.proj.bias"] = old_state_dict["vivit.embeddings.patch_embeddings.projection.bias"] 
+    new_state_dict["pos_embed.W_pos"] = old_state_dict[
+        "vivit.embeddings.position_embeddings"
+    ].squeeze(0)
+    new_state_dict["embed.proj.weight"] = old_state_dict[
+        "vivit.embeddings.patch_embeddings.projection.weight"
+    ]
+    new_state_dict["embed.proj.bias"] = old_state_dict[
+        "vivit.embeddings.patch_embeddings.projection.bias"
+    ]
     new_state_dict["ln_final.w"] = old_state_dict["vivit.layernorm.weight"]
     new_state_dict["ln_final.b"] = old_state_dict["vivit.layernorm.bias"]
 
     for layer in range(cfg.n_layers):
-        layer_key = f"vivit.encoder.layer.{layer}" 
+        layer_key = f"vivit.encoder.layer.{layer}"
         new_layer_key = f"blocks.{layer}"
-        new_state_dict[f"{new_layer_key}.ln1.w"] = old_state_dict[f"{layer_key}.layernorm_before.weight"]
-        new_state_dict[f"{new_layer_key}.ln1.b"] = old_state_dict[f"{layer_key}.layernorm_before.bias"]
-        new_state_dict[f"{new_layer_key}.ln2.w"] = old_state_dict[f"{layer_key}.layernorm_after.weight"]
-        new_state_dict[f"{new_layer_key}.ln2.b"] = old_state_dict[f"{layer_key}.layernorm_after.bias"]
+        new_state_dict[f"{new_layer_key}.ln1.w"] = old_state_dict[
+            f"{layer_key}.layernorm_before.weight"
+        ]
+        new_state_dict[f"{new_layer_key}.ln1.b"] = old_state_dict[
+            f"{layer_key}.layernorm_before.bias"
+        ]
+        new_state_dict[f"{new_layer_key}.ln2.w"] = old_state_dict[
+            f"{layer_key}.layernorm_after.weight"
+        ]
+        new_state_dict[f"{new_layer_key}.ln2.b"] = old_state_dict[
+            f"{layer_key}.layernorm_after.bias"
+        ]
 
-        W_Q  = old_state_dict[f"{layer_key}.attention.attention.query.weight"]
-        W_K  = old_state_dict[f"{layer_key}.attention.attention.key.weight"]
-        W_V  = old_state_dict[f"{layer_key}.attention.attention.value.weight"]
+        W_Q = old_state_dict[f"{layer_key}.attention.attention.query.weight"]
+        W_K = old_state_dict[f"{layer_key}.attention.attention.key.weight"]
+        W_V = old_state_dict[f"{layer_key}.attention.attention.value.weight"]
 
-        new_state_dict[f"{new_layer_key}.attn.W_Q"] = einops.rearrange(W_Q, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
-        new_state_dict[f"{new_layer_key}.attn.W_K"] = einops.rearrange(W_K, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
-        new_state_dict[f"{new_layer_key}.attn.W_V"] = einops.rearrange(W_V, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
+        new_state_dict[f"{new_layer_key}.attn.W_Q"] = einops.rearrange(
+            W_Q, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
+        new_state_dict[f"{new_layer_key}.attn.W_K"] = einops.rearrange(
+            W_K, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
+        new_state_dict[f"{new_layer_key}.attn.W_V"] = einops.rearrange(
+            W_V, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
 
         W_O = old_state_dict[f"{layer_key}.attention.output.dense.weight"]
-        new_state_dict[f"{new_layer_key}.attn.W_O"] =  einops.rearrange(W_O, "d (h dh) -> h dh d", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
+        new_state_dict[f"{new_layer_key}.attn.W_O"] = einops.rearrange(
+            W_O, "d (h dh) -> h dh d", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
 
+        b_Q = old_state_dict[f"{layer_key}.attention.attention.query.bias"]
+        b_K = old_state_dict[f"{layer_key}.attention.attention.key.bias"]
+        b_V = old_state_dict[f"{layer_key}.attention.attention.value.bias"]
 
-        b_Q  = old_state_dict[f"{layer_key}.attention.attention.query.bias"]
-        b_K  = old_state_dict[f"{layer_key}.attention.attention.key.bias"]
-        b_V  = old_state_dict[f"{layer_key}.attention.attention.value.bias"]
-
-        new_state_dict[f"{new_layer_key}.attn.b_Q"] = einops.rearrange(b_Q, "(h dh) -> h dh",  h=cfg.n_heads, dh=cfg.d_head)
-        new_state_dict[f"{new_layer_key}.attn.b_K"] = einops.rearrange(b_K, "(h dh) -> h dh",  h=cfg.n_heads, dh=cfg.d_head)
-        new_state_dict[f"{new_layer_key}.attn.b_V"] = einops.rearrange(b_V, "(h dh) -> h dh",  h=cfg.n_heads, dh=cfg.d_head)
+        new_state_dict[f"{new_layer_key}.attn.b_Q"] = einops.rearrange(
+            b_Q, "(h dh) -> h dh", h=cfg.n_heads, dh=cfg.d_head
+        )
+        new_state_dict[f"{new_layer_key}.attn.b_K"] = einops.rearrange(
+            b_K, "(h dh) -> h dh", h=cfg.n_heads, dh=cfg.d_head
+        )
+        new_state_dict[f"{new_layer_key}.attn.b_V"] = einops.rearrange(
+            b_V, "(h dh) -> h dh", h=cfg.n_heads, dh=cfg.d_head
+        )
 
         b_O = old_state_dict[f"{layer_key}.attention.output.dense.bias"]
         new_state_dict[f"{new_layer_key}.attn.b_O"] = b_O
 
         mlp_W_in = old_state_dict[f"{layer_key}.intermediate.dense.weight"]
-        new_state_dict[f"{new_layer_key}.mlp.W_in"] =  einops.rearrange(mlp_W_in, "m d -> d m")
+        new_state_dict[f"{new_layer_key}.mlp.W_in"] = einops.rearrange(
+            mlp_W_in, "m d -> d m"
+        )
 
-        mlp_W_out  = old_state_dict[f"{layer_key}.output.dense.weight"]
-       
-        new_state_dict[f"{new_layer_key}.mlp.W_out"] = einops.rearrange(mlp_W_out, "d m -> m d")
+        mlp_W_out = old_state_dict[f"{layer_key}.output.dense.weight"]
 
-        new_state_dict[f"{new_layer_key}.mlp.b_in"] =  old_state_dict[f"{layer_key}.intermediate.dense.bias"]
-        new_state_dict[f"{new_layer_key}.mlp.b_out"] =  old_state_dict[f"{layer_key}.output.dense.bias"]
+        new_state_dict[f"{new_layer_key}.mlp.W_out"] = einops.rearrange(
+            mlp_W_out, "d m -> m d"
+        )
 
+        new_state_dict[f"{new_layer_key}.mlp.b_in"] = old_state_dict[
+            f"{layer_key}.intermediate.dense.bias"
+        ]
+        new_state_dict[f"{new_layer_key}.mlp.b_out"] = old_state_dict[
+            f"{layer_key}.output.dense.bias"
+        ]
 
-    new_state_dict["head.W_H"] = einops.rearrange(old_state_dict["classifier.weight"], "c d -> d c")
+    new_state_dict["head.W_H"] = einops.rearrange(
+        old_state_dict["classifier.weight"], "c d -> d c"
+    )
     new_state_dict["head.b_H"] = old_state_dict["classifier.bias"]
-
-
 
     return new_state_dict
 
-def convert_hf_vit_for_image_classification_weights(   old_state_dict,
-        cfg: HookedViTConfig,
+
+def convert_hf_vit_for_image_classification_weights(
+    old_state_dict,
+    cfg: HookedViTConfig,
 ):
 
     new_state_dict = {}
 
-    #exit(0)
+    # exit(0)
     new_state_dict["cls_token"] = old_state_dict["vit.embeddings.cls_token"]
-    new_state_dict["pos_embed.W_pos"] = old_state_dict["vit.embeddings.position_embeddings"].squeeze(0)
-    new_state_dict["embed.proj.weight"] = old_state_dict["vit.embeddings.patch_embeddings.projection.weight"]
-    new_state_dict["embed.proj.bias"] = old_state_dict["vit.embeddings.patch_embeddings.projection.bias"] 
+    new_state_dict["pos_embed.W_pos"] = old_state_dict[
+        "vit.embeddings.position_embeddings"
+    ].squeeze(0)
+    new_state_dict["embed.proj.weight"] = old_state_dict[
+        "vit.embeddings.patch_embeddings.projection.weight"
+    ]
+    new_state_dict["embed.proj.bias"] = old_state_dict[
+        "vit.embeddings.patch_embeddings.projection.bias"
+    ]
     new_state_dict["ln_final.w"] = old_state_dict["vit.layernorm.weight"]
     new_state_dict["ln_final.b"] = old_state_dict["vit.layernorm.bias"]
 
     for layer in range(cfg.n_layers):
-        layer_key = f"vit.encoder.layer.{layer}" 
+        layer_key = f"vit.encoder.layer.{layer}"
         new_layer_key = f"blocks.{layer}"
-        new_state_dict[f"{new_layer_key}.ln1.w"] = old_state_dict[f"{layer_key}.layernorm_before.weight"]
-        new_state_dict[f"{new_layer_key}.ln1.b"] = old_state_dict[f"{layer_key}.layernorm_before.bias"]
-        new_state_dict[f"{new_layer_key}.ln2.w"] = old_state_dict[f"{layer_key}.layernorm_after.weight"]
-        new_state_dict[f"{new_layer_key}.ln2.b"] = old_state_dict[f"{layer_key}.layernorm_after.bias"]
+        new_state_dict[f"{new_layer_key}.ln1.w"] = old_state_dict[
+            f"{layer_key}.layernorm_before.weight"
+        ]
+        new_state_dict[f"{new_layer_key}.ln1.b"] = old_state_dict[
+            f"{layer_key}.layernorm_before.bias"
+        ]
+        new_state_dict[f"{new_layer_key}.ln2.w"] = old_state_dict[
+            f"{layer_key}.layernorm_after.weight"
+        ]
+        new_state_dict[f"{new_layer_key}.ln2.b"] = old_state_dict[
+            f"{layer_key}.layernorm_after.bias"
+        ]
 
-        W_Q  = old_state_dict[f"{layer_key}.attention.attention.query.weight"]
-        W_K  = old_state_dict[f"{layer_key}.attention.attention.key.weight"]
-        W_V  = old_state_dict[f"{layer_key}.attention.attention.value.weight"]
+        W_Q = old_state_dict[f"{layer_key}.attention.attention.query.weight"]
+        W_K = old_state_dict[f"{layer_key}.attention.attention.key.weight"]
+        W_V = old_state_dict[f"{layer_key}.attention.attention.value.weight"]
 
-        new_state_dict[f"{new_layer_key}.attn.W_Q"] = einops.rearrange(W_Q, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
-        new_state_dict[f"{new_layer_key}.attn.W_K"] = einops.rearrange(W_K, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
-        new_state_dict[f"{new_layer_key}.attn.W_V"] = einops.rearrange(W_V, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
+        new_state_dict[f"{new_layer_key}.attn.W_Q"] = einops.rearrange(
+            W_Q, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
+        new_state_dict[f"{new_layer_key}.attn.W_K"] = einops.rearrange(
+            W_K, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
+        new_state_dict[f"{new_layer_key}.attn.W_V"] = einops.rearrange(
+            W_V, "(h dh) d -> h d dh", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
 
         W_O = old_state_dict[f"{layer_key}.attention.output.dense.weight"]
-        new_state_dict[f"{new_layer_key}.attn.W_O"] =  einops.rearrange(W_O, "d (h dh) -> h dh d", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head)
+        new_state_dict[f"{new_layer_key}.attn.W_O"] = einops.rearrange(
+            W_O, "d (h dh) -> h dh d", h=cfg.n_heads, d=cfg.d_model, dh=cfg.d_head
+        )
 
+        b_Q = old_state_dict[f"{layer_key}.attention.attention.query.bias"]
+        b_K = old_state_dict[f"{layer_key}.attention.attention.key.bias"]
+        b_V = old_state_dict[f"{layer_key}.attention.attention.value.bias"]
 
-        b_Q  = old_state_dict[f"{layer_key}.attention.attention.query.bias"]
-        b_K  = old_state_dict[f"{layer_key}.attention.attention.key.bias"]
-        b_V  = old_state_dict[f"{layer_key}.attention.attention.value.bias"]
-
-        new_state_dict[f"{new_layer_key}.attn.b_Q"] = einops.rearrange(b_Q, "(h dh) -> h dh",  h=cfg.n_heads, dh=cfg.d_head)
-        new_state_dict[f"{new_layer_key}.attn.b_K"] = einops.rearrange(b_K, "(h dh) -> h dh",  h=cfg.n_heads, dh=cfg.d_head)
-        new_state_dict[f"{new_layer_key}.attn.b_V"] = einops.rearrange(b_V, "(h dh) -> h dh",  h=cfg.n_heads, dh=cfg.d_head)
+        new_state_dict[f"{new_layer_key}.attn.b_Q"] = einops.rearrange(
+            b_Q, "(h dh) -> h dh", h=cfg.n_heads, dh=cfg.d_head
+        )
+        new_state_dict[f"{new_layer_key}.attn.b_K"] = einops.rearrange(
+            b_K, "(h dh) -> h dh", h=cfg.n_heads, dh=cfg.d_head
+        )
+        new_state_dict[f"{new_layer_key}.attn.b_V"] = einops.rearrange(
+            b_V, "(h dh) -> h dh", h=cfg.n_heads, dh=cfg.d_head
+        )
 
         b_O = old_state_dict[f"{layer_key}.attention.output.dense.bias"]
         new_state_dict[f"{new_layer_key}.attn.b_O"] = b_O
 
         mlp_W_in = old_state_dict[f"{layer_key}.intermediate.dense.weight"]
-        new_state_dict[f"{new_layer_key}.mlp.W_in"] =  einops.rearrange(mlp_W_in, "m d -> d m")
+        new_state_dict[f"{new_layer_key}.mlp.W_in"] = einops.rearrange(
+            mlp_W_in, "m d -> d m"
+        )
 
-        mlp_W_out  = old_state_dict[f"{layer_key}.output.dense.weight"]
-       
-        new_state_dict[f"{new_layer_key}.mlp.W_out"] = einops.rearrange(mlp_W_out, "d m -> m d")
+        mlp_W_out = old_state_dict[f"{layer_key}.output.dense.weight"]
 
-        new_state_dict[f"{new_layer_key}.mlp.b_in"] =  old_state_dict[f"{layer_key}.intermediate.dense.bias"]
-        new_state_dict[f"{new_layer_key}.mlp.b_out"] =  old_state_dict[f"{layer_key}.output.dense.bias"]
+        new_state_dict[f"{new_layer_key}.mlp.W_out"] = einops.rearrange(
+            mlp_W_out, "d m -> m d"
+        )
 
-    new_state_dict["head.W_H"] = einops.rearrange(old_state_dict["classifier.weight"], "c d -> d c")
+        new_state_dict[f"{new_layer_key}.mlp.b_in"] = old_state_dict[
+            f"{layer_key}.intermediate.dense.bias"
+        ]
+        new_state_dict[f"{new_layer_key}.mlp.b_out"] = old_state_dict[
+            f"{layer_key}.output.dense.bias"
+        ]
+
+    new_state_dict["head.W_H"] = einops.rearrange(
+        old_state_dict["classifier.weight"], "c d -> d c"
+    )
     new_state_dict["head.b_H"] = old_state_dict["classifier.bias"]
-
-
 
     return new_state_dict
 
 
-def convert_open_clip_config(model_cfg: dict, model_name: str, model_type: ModelType = ModelType.VISION):
+def convert_open_clip_config(
+    model_cfg: dict, model_name: str, model_type: ModelType = ModelType.VISION
+):
     if model_type == ModelType.TEXT:
         cfg = HookedTextTransformerConfig()
-        cfg.d_model = model_cfg['text_cfg']['width']
-        cfg.n_layers = model_cfg['text_cfg']['layers']
-        cfg.context_length = model_cfg['text_cfg']['context_length']
-        cfg.vocab_size = model_cfg['text_cfg']['vocab_size']
-        cfg.n_heads = model_cfg['text_cfg']['heads']
+        cfg.d_model = model_cfg["text_cfg"]["width"]
+        cfg.n_layers = model_cfg["text_cfg"]["layers"]
+        cfg.context_length = model_cfg["text_cfg"]["context_length"]
+        cfg.vocab_size = model_cfg["text_cfg"]["vocab_size"]
+        cfg.n_heads = model_cfg["text_cfg"]["heads"]
         cfg.use_cls_token = False
     else:
         cfg = HookedViTConfig()
-        cfg.d_model = model_cfg['vision_cfg']['width']
-        cfg.n_layers = model_cfg['vision_cfg']['layers']
-        cfg.patch_size = model_cfg['vision_cfg']['patch_size']
-        cfg.image_size = model_cfg['vision_cfg']['image_size']
+        cfg.d_model = model_cfg["vision_cfg"]["width"]
+        cfg.n_layers = model_cfg["vision_cfg"]["layers"]
+        cfg.patch_size = model_cfg["vision_cfg"]["patch_size"]
+        cfg.image_size = model_cfg["vision_cfg"]["image_size"]
         cfg.use_cls_token = True
         cfg.d_mlp = cfg.d_model * 4
         cfg.d_head = cfg.d_model // cfg.n_heads
-        cfg.n_classes = model_cfg['embed_dim'] # This is the projection dimensionality
+        cfg.n_classes = model_cfg["embed_dim"]  # This is the projection dimensionality
         cfg.return_type = None
         cfg.layer_norm_pre = True
         cfg.eps = 1e-5
         cfg.normalization_type = "LN"
         cfg.normalize_output = True
-        if model_name == 'open-clip:laion/CLIP-ViT-L-14-DataComp.XL-s13B-b90K':
+        if model_name == "open-clip:laion/CLIP-ViT-L-14-DataComp.XL-s13B-b90K":
             cfg.layer_norm_pre = True
             cfg.return_type = "class_logits"  # actually returns 'visual_projection'
             cfg.n_heads = 16
@@ -647,19 +864,26 @@ def get_pretrained_state_dict(
     #         f"Loading model {official_model_name} state dict requires setting trust_remote_code=True"
     #     )
     #     kwargs["trust_remote_code"] = True
-    if 'dino' in official_model_name:
+    if "dino" in official_model_name:
         is_timm = False
-        
+
     try:
-        print("Official model name", official_model_name)
+        logging.info("Official model name", official_model_name)
         if is_timm:
-            hf_model = hf_model if hf_model is not None else timm.create_model(official_model_name, pretrained=True)
+            hf_model = (
+                hf_model
+                if hf_model is not None
+                else timm.create_model(official_model_name, pretrained=True)
+            )
             for param in hf_model.parameters():
                 param.requires_grad = False
             state_dict = convert_timm_weights(hf_model.state_dict(), cfg)
         elif is_clip and official_model_name.startswith("open-clip:"):
-            print("Converting OpenCLIP weights")
-            checkpoint_path = download_pretrained_from_hf(remove_open_clip_prefix(official_model_name), filename='open_clip_pytorch_model.bin')
+            logging.info("Converting OpenCLIP weights")
+            checkpoint_path = download_pretrained_from_hf(
+                remove_open_clip_prefix(official_model_name),
+                filename="open_clip_pytorch_model.bin",
+            )
             old_state_dict = load_state_dict(checkpoint_path)
             if model_type == ModelType.VISION:
                 state_dict = convert_open_clip_weights(old_state_dict, cfg)
@@ -667,26 +891,39 @@ def get_pretrained_state_dict(
                 state_dict = convert_open_clip_text_weights(old_state_dict, cfg)
             state_dict = convert_open_clip_weights(old_state_dict, cfg)
         elif is_clip and official_model_name.startswith("kandinsky"):
-            print("Converting Kandinsky weights")
+            logging.info("Converting Kandinsky weights")
             from transformers import CLIPVisionModelWithProjection
+
             hf_model = CLIPVisionModelWithProjection.from_pretrained(
-                'kandinsky-community/kandinsky-2-1-prior',
-                subfolder='image_encoder',
+                "kandinsky-community/kandinsky-2-1-prior",
+                subfolder="image_encoder",
                 torch_dtype=torch.float16,
-                cache_dir = '/network/scratch/s/sonia.joseph/diffusion'
+                cache_dir="/network/scratch/s/sonia.joseph/diffusion",
             ).to("cuda")
             old_state_dict = hf_model.state_dict()
             state_dict = convert_kandinsky_clip_weights(old_state_dict, cfg)
         elif is_clip:
-            full_model = hf_model if hf_model is not None else CLIPModel.from_pretrained(official_model_name)
+            full_model = (
+                hf_model
+                if hf_model is not None
+                else CLIPModel.from_pretrained(official_model_name)
+            )
             for param in full_model.parameters():
                 param.requires_grad = False
             vision = full_model.vision_model
             visual_projection = full_model.visual_projection
-            state_dict = convert_clip_weights(vision.state_dict(), visual_projection.state_dict(), cfg)
+            state_dict = convert_clip_weights(
+                vision.state_dict(), visual_projection.state_dict(), cfg
+            )
         elif cfg.is_video_transformer:
             if "vivit" in official_model_name:
-                hf_model = hf_model if hf_model is not None else VivitForVideoClassification.from_pretrained(official_model_name, torch_dtype=dtype, **kwargs)
+                hf_model = (
+                    hf_model
+                    if hf_model is not None
+                    else VivitForVideoClassification.from_pretrained(
+                        official_model_name, torch_dtype=dtype, **kwargs
+                    )
+                )
 
                 for param in hf_model.parameters():
                     param.requires_grad = False
@@ -695,32 +932,42 @@ def get_pretrained_state_dict(
             else:
                 raise ValueError
 
-        elif 'dino' in official_model_name:
-            hf_model = hf_model if hf_model is not None else ViTModel.from_pretrained(official_model_name, torch_dtype=dtype, **kwargs)
+        elif "dino" in official_model_name:
+            hf_model = (
+                hf_model
+                if hf_model is not None
+                else ViTModel.from_pretrained(
+                    official_model_name, torch_dtype=dtype, **kwargs
+                )
+            )
             for param in hf_model.parameters():
                 param.requires_grad = False
             state_dict = convert_dino_weights(hf_model.state_dict(), cfg)
-        
+
         else:
-            hf_model = hf_model if hf_model is not None else ViTForImageClassification.from_pretrained(
+            hf_model = (
+                hf_model
+                if hf_model is not None
+                else ViTForImageClassification.from_pretrained(
                     official_model_name, torch_dtype=dtype, **kwargs
+                )
             )
-            state_dict = convert_hf_vit_for_image_classification_weights(hf_model.state_dict(), cfg)
+            state_dict = convert_hf_vit_for_image_classification_weights(
+                hf_model.state_dict(), cfg
+            )
 
             # Load model weights, and fold in layer norm weights
-                
-        return state_dict
 
+        return state_dict
 
     except Exception as e:
 
         raise ValueError(
-
             f"Loading weights from the architecture is not currently supported: "
             f"{cfg.original_architecture}, generated from model name {cfg.model_name}. "
             f"Feel free to open an issue on GitHub to request this feature."
-
         ) from e
+
 
 def fill_missing_keys(model, state_dict):
     """Takes in a state dict from a pretrained model, and fills in any missing keys with the default initialization.
@@ -754,126 +1001,147 @@ def fill_missing_keys(model, state_dict):
 
 def remove_open_clip_prefix(text, prefix="open-clip:"):
     if text.startswith(prefix):
-        return text[len(prefix):]
-    return text 
+        return text[len(prefix) :]
+    return text
 
-def convert_pretrained_model_config(model_name: str, is_timm: bool = True, is_clip: bool = False, model_type=ModelType.VISION) -> HookedViTConfig:
 
-    
-    if 'dino' in model_name:
+def convert_pretrained_model_config(
+    model_name: str,
+    is_timm: bool = True,
+    is_clip: bool = False,
+    model_type=ModelType.VISION,
+) -> HookedViTConfig:
+
+    if "dino" in model_name:
         is_timm = False
-        
+
     if is_timm:
         model = timm.create_model(model_name)
-        hf_config = AutoConfig.from_pretrained(model.default_cfg['hf_hub_id'])
-    elif is_clip and model_name.startswith("open-clip"): # OpenCLIP models
-        config_path = download_pretrained_from_hf(remove_open_clip_prefix(model_name), filename='open_clip_config.json')
-        with open(config_path, 'r', encoding='utf-8') as f:
+        hf_config = AutoConfig.from_pretrained(model.default_cfg["hf_hub_id"])
+    elif is_clip and model_name.startswith("open-clip"):  # OpenCLIP models
+        config_path = download_pretrained_from_hf(
+            remove_open_clip_prefix(model_name), filename="open_clip_config.json"
+        )
+        with open(config_path, "r", encoding="utf-8") as f:
             config = json.load(f)
-            pretrained_cfg = config['preprocess_cfg']
-            hf_config = config['model_cfg']
-        hf_config = convert_open_clip_config(hf_config, model_name, model_type=model_type)
+            pretrained_cfg = config["preprocess_cfg"]
+            hf_config = config["model_cfg"]
+        hf_config = convert_open_clip_config(
+            hf_config, model_name, model_type=model_type
+        )
         return hf_config
     elif is_clip and model_name.startswith("kandinsky"):
         from types import SimpleNamespace
-        hf_config = {"_name_or_path": "kandinsky-community/kandinsky-2-1-prior",
-                "architectures": [
-                    "CLIPVisionModelWithProjection"
-                ],
-                "attention_dropout": 0.0,
-                "dropout": 0.0,
-                "hidden_act": "quick_gelu",
-                "hidden_size": 1024,
-                "image_size": 224,
-                "initializer_factor": 1.0,
-                "initializer_range": 0.02,
-                "intermediate_size": 4096,
-                "layer_norm_eps": 1e-05,
-                "model_type": "clip_vision_model",
-                "num_attention_heads": 16,
-                "num_channels": 3,
-                "num_hidden_layers": 24,
-                "patch_size": 14,
-                "projection_dim": 768,
-                "transformers_version": "4.39.3"
-                }
+
+        hf_config = {
+            "_name_or_path": "kandinsky-community/kandinsky-2-1-prior",
+            "architectures": ["CLIPVisionModelWithProjection"],
+            "attention_dropout": 0.0,
+            "dropout": 0.0,
+            "hidden_act": "quick_gelu",
+            "hidden_size": 1024,
+            "image_size": 224,
+            "initializer_factor": 1.0,
+            "initializer_range": 0.02,
+            "intermediate_size": 4096,
+            "layer_norm_eps": 1e-05,
+            "model_type": "clip_vision_model",
+            "num_attention_heads": 16,
+            "num_channels": 3,
+            "num_hidden_layers": 24,
+            "patch_size": 14,
+            "projection_dim": 768,
+            "transformers_version": "4.39.3",
+        }
         hf_config = SimpleNamespace(**hf_config)
-        print("HF config:", hf_config)
-    elif is_clip: # Extract vision encoder from dual-encoder CLIP model. HF models
+        logging.info("HF config:", hf_config)
+    elif is_clip:  # Extract vision encoder from dual-encoder CLIP model. HF models
         hf_config = AutoConfig.from_pretrained(model_name).vision_config
-        hf_config.architecture = 'vit_clip_vision_encoder'
-        hf_config.num_classes = hf_config.projection_dim # final output dimension instead of classes
+        hf_config.architecture = "vit_clip_vision_encoder"
+        hf_config.num_classes = (
+            hf_config.projection_dim
+        )  # final output dimension instead of classes
     else:
         hf_config = AutoConfig.from_pretrained(model_name)
 
-    if hasattr(hf_config, 'patch_size'):
+    if hasattr(hf_config, "patch_size"):
         ps = hf_config.patch_size
     elif hasattr(hf_config, "tubelet_size"):
         ps = hf_config.tubelet_size[1]
 
     pretrained_config = {
-                    'n_layers' : hf_config.num_hidden_layers,
-                    'd_model' : hf_config.hidden_size,
-                    'd_head' : hf_config.hidden_size // hf_config.num_attention_heads,
-                    'model_name' : hf_config._name_or_path,
-                    'n_heads' : hf_config.num_attention_heads,
-                    'd_mlp' : hf_config.intermediate_size,
-                    'activation_name' : hf_config.hidden_act,
-                    'eps' : hf_config.layer_norm_eps,
-                    'original_architecture' : getattr(hf_config, 'architecture', getattr(hf_config, 'architectures', None)),
-                    'initializer_range' : hf_config.initializer_range,
-                    'n_channels' : hf_config.num_channels,
-                    'patch_size' : ps,
-                    'image_size' : hf_config.image_size,
-                    'n_classes': getattr(hf_config, "num_classes", getattr(hf_config, "projection_dim", None)),
-                    'n_params' : sum(p.numel() for p in model.parameters() if p.requires_grad) if is_timm else None,
-                }
-    
+        "n_layers": hf_config.num_hidden_layers,
+        "d_model": hf_config.hidden_size,
+        "d_head": hf_config.hidden_size // hf_config.num_attention_heads,
+        "model_name": hf_config._name_or_path,
+        "n_heads": hf_config.num_attention_heads,
+        "d_mlp": hf_config.intermediate_size,
+        "activation_name": hf_config.hidden_act,
+        "eps": hf_config.layer_norm_eps,
+        "original_architecture": getattr(
+            hf_config, "architecture", getattr(hf_config, "architectures", None)
+        ),
+        "initializer_range": hf_config.initializer_range,
+        "n_channels": hf_config.num_channels,
+        "patch_size": ps,
+        "image_size": hf_config.image_size,
+        "n_classes": getattr(
+            hf_config, "num_classes", getattr(hf_config, "projection_dim", None)
+        ),
+        "n_params": (
+            sum(p.numel() for p in model.parameters() if p.requires_grad)
+            if is_timm
+            else None
+        ),
+    }
+
     # Rectifying Huggingface bugs:
     # Currently a bug getting configs, only this model confirmed to work and even it requires modification of eps
     if is_timm and model_name == "vit_base_patch16_224":
-        pretrained_config.update({
-            "eps": 1e-6,
-            "return_type": "class_logits",
-        })
-    
-    # Config for 32 is incorrect, fix manually 
-    if is_timm and model_name == "vit_base_patch32_224":
-        pretrained_config.update({
-            "patch_size": 32,
-            "eps": 1e-6,
-            "return_type": "class_logits"
-        })
+        pretrained_config.update(
+            {
+                "eps": 1e-6,
+                "return_type": "class_logits",
+            }
+        )
 
-        
-    print("Model name is ", model_name)
-    
+    # Config for 32 is incorrect, fix manually
+    if is_timm and model_name == "vit_base_patch32_224":
+        pretrained_config.update(
+            {"patch_size": 32, "eps": 1e-6, "return_type": "class_logits"}
+        )
+
+    logging.info("Model name is ", model_name)
 
     if "dino" in model_name:
-        pretrained_config.update({
-            "return_type": "pre_logits",
-            "n_classes": 768,
-        })
+        pretrained_config.update(
+            {
+                "return_type": "pre_logits",
+                "n_classes": 768,
+            }
+        )
 
     # Config is for ViVet, need to add more properties
     if hasattr(hf_config, "tubelet_size"):
-        pretrained_config.update({
-            "is_video_transformer": True,
-            "video_tubelet_depth": hf_config.tubelet_size[0],
-            "video_num_frames": hf_config.video_size[0],
-            "n_classes": 400 if "kinetics400" in model_name else None,
-            "return_type": "class_logits" if "kinetics400" in model_name else "pre_logits",
+        pretrained_config.update(
+            {
+                "is_video_transformer": True,
+                "video_tubelet_depth": hf_config.tubelet_size[0],
+                "video_num_frames": hf_config.video_size[0],
+                "n_classes": 400 if "kinetics400" in model_name else None,
+                "return_type": (
+                    "class_logits" if "kinetics400" in model_name else "pre_logits"
+                ),
+            }
+        )
 
-        })
-
-    if pretrained_config['n_classes'] is None:
+    if pretrained_config["n_classes"] is None:
         id2label = getattr(hf_config, "id2label", None)
         if id2label is not None:
-            pretrained_config.update({
-                "n_classes": len(id2label),
-                "return_type": "class_logits"
-            })
-    
+            pretrained_config.update(
+                {"n_classes": len(id2label), "return_type": "class_logits"}
+            )
+
     config = HookedViTConfig.from_dict(pretrained_config)
     return config
 
@@ -882,30 +1150,37 @@ def has_hf_hub(necessary=False):
     if not _has_hf_hub and necessary:
         # if no HF Hub module installed, and it is necessary to continue, raise error
         raise RuntimeError(
-            'Hugging Face hub model specified but package not installed. Run `pip install huggingface_hub`.')
+            "Hugging Face hub model specified but package not installed. Run `pip install huggingface_hub`."
+        )
     return _has_hf_hub
 
 
 def download_pretrained_from_hf(
-        model_id: str,
-        filename: str = 'open_clip_pytorch_model.bin',
-        revision=None,
-        cache_dir: Union[str, None] = None,
+    model_id: str,
+    filename: str = "open_clip_pytorch_model.bin",
+    revision=None,
+    cache_dir: Union[str, None] = None,
 ):
-    print("model_id download_pretrained_from_hf:", model_id)
+    logging.info("model_id download_pretrained_from_hf:", model_id)
     has_hf_hub(True)
-    cached_file = hf_hub_download(model_id, filename, revision=revision, cache_dir=cache_dir)
+    cached_file = hf_hub_download(
+        model_id, filename, revision=revision, cache_dir=cache_dir
+    )
     return cached_file
 
-def load_state_dict(checkpoint_path: str, map_location='cpu'):
-    checkpoint = torch.load(checkpoint_path, map_location=map_location)
-    if isinstance(checkpoint, dict) and 'state_dict' in checkpoint:
-        state_dict = checkpoint['state_dict']
+
+def load_state_dict(checkpoint_path: str, map_location="cpu"):
+    checkpoint = torch.load(
+        checkpoint_path, map_location=map_location, weights_only=False
+    )
+    if isinstance(checkpoint, dict) and "state_dict" in checkpoint:
+        state_dict = checkpoint["state_dict"]
     else:
         state_dict = checkpoint
-    if next(iter(state_dict.items()))[0].startswith('module'):
+    if next(iter(state_dict.items()))[0].startswith("module"):
         state_dict = {k[7:]: v for k, v in state_dict.items()}
     return state_dict
+
 
 # checkpoint_path = download_pretrained_from_hf('laion/CLIP-ViT-B-32-DataComp.XL-s13B-b90K', filename='open_clip_pytorch_model.bin')
 # config_path = download_pretrained_from_hf('laion/CLIP-ViT-B-32-DataComp.XL-s13B-b90K', filename='open_clip_config.json')
@@ -915,21 +1190,19 @@ def load_state_dict(checkpoint_path: str, map_location='cpu'):
 #     pretrained_cfg = config['preprocess_cfg']
 #     model_cfg = config['model_cfg']
 
-#     print(pretrained_cfg)
-#     print(model_cfg)
+#     logging.info(pretrained_cfg)
+#     logging.info(model_cfg)
 
 # state_dict = load_state_dict(checkpoint_path)
 
-# print("old state dictionary")
+# logging.info("old state dictionary")
 # for key in state_dict:
-#     print(key, state_dict[key].shape)
+#     logging.info(key, state_dict[key].shape)
 
 # new_cfg = convert_open_clip_config(model_cfg)
 # new_state_dict = convert_open_clip_weights(state_dict, new_cfg)
 
-# print()
-# print("new state dictionary")
+# logging.info()
+# logging.info("new state dictionary")
 # for key in new_state_dict:
-#     print(key, new_state_dict[key].shape)
-
-
+#     logging.info(key, new_state_dict[key].shape)

--- a/src/vit_prisma/sae/config.py
+++ b/src/vit_prisma/sae/config.py
@@ -3,6 +3,7 @@ import math
 from abc import ABC
 from dataclasses import fields, field, asdict, dataclass
 from typing import Any, Optional, Literal
+import logging
 
 import torch
 from vit_prisma.configs.HookedViTConfig import HookedViTConfig
@@ -143,7 +144,7 @@ class VisionModelSAERunnerConfig(RunnerConfig):
     wandb_log_frequency: int = 10
 
     # Misc
-    n_validation_runs: int = 100 # spaced linearly throughout training
+    n_validation_runs: int = 100  # spaced linearly throughout training
     n_checkpoints: int = 10
     checkpoint_path: str = (
         "/network/scratch/s/sonia.joseph/sae_checkpoints/tinyclip_40M_mlp_out"
@@ -161,7 +162,7 @@ class VisionModelSAERunnerConfig(RunnerConfig):
                 f"b_dec_init_method must be geometric_median, mean, or zeros. Got {self.b_dec_init_method}"
             )
         if self.b_dec_init_method == "zeros":
-            print(
+            logging.warning(
                 "Warning: We are initializing b_dec to zeros. This is probably not what you want."
             )
 
@@ -171,51 +172,51 @@ class VisionModelSAERunnerConfig(RunnerConfig):
         n_tokens_per_buffer = (
             self.store_batch_size * self.context_size * self.n_batches_in_buffer
         )
-        print(f"n_tokens_per_buffer (millions): {n_tokens_per_buffer / 10 **6}")
+        logging.info(f"n_tokens_per_buffer (millions): {n_tokens_per_buffer / 10 **6}")
         n_contexts_per_buffer = self.store_batch_size * self.n_batches_in_buffer
-        print(
+        logging.info(
             f"Lower bound: n_contexts_per_buffer (millions): {n_contexts_per_buffer / 10 **6}"
         )
 
         self.total_training_steps = self.total_training_tokens // self.train_batch_size
-        print(f"Total training steps: {self.total_training_steps}")
+        logging.info(f"Total training steps: {self.total_training_steps}")
 
-        print(f"Total training images: {self.total_training_images}")
+        logging.info(f"Total training images: {self.total_training_images}")
 
         total_wandb_updates = self.total_training_steps // self.wandb_log_frequency
-        print(f"Total wandb updates: {total_wandb_updates}")
+        logging.info(f"Total wandb updates: {total_wandb_updates}")
 
-        # print expansion factor
-        print(f"Expansion factor: {self.expansion_factor}")
+        # print  expansion factor
+        logging.info(f"Expansion factor: {self.expansion_factor}")
 
         # how many times will we sample dead neurons?
         # assert self.dead_feature_window <= self.feature_sampling_window, "dead_feature_window must be smaller than feature_sampling_window"
         n_feature_window_samples = (
             self.total_training_steps // self.feature_sampling_window
         )
-        print(
+        logging.info(
             f"n_tokens_per_feature_sampling_window (millions): {(self.feature_sampling_window * self.context_size * self.train_batch_size) / 10 **6}"
         )
-        print(
+        logging.info(
             f"n_tokens_per_dead_feature_window (millions): {(self.dead_feature_window * self.context_size * self.train_batch_size) / 10 **6}"
         )
 
         if self.use_ghost_grads:
-            print("Using Ghost Grads.")
+            logging.info("Using Ghost Grads.")
 
-        print(
+        logging.info(
             f"We will reset the sparsity calculation {n_feature_window_samples} times."
         )
-        # print("Number tokens in dead feature calculation window: ", self.dead_feature_window * self.train_batch_size)
-        print(
+        # print ("Number tokens in dead feature calculation window: ", self.dead_feature_window * self.train_batch_size)
+        logging.info(
             f"Number tokens in sparsity calculation window: {self.feature_sampling_window * self.train_batch_size:.2e}"
         )
 
         if self.max_grad_norm:
-            print(f"Gradient clipping with max_norm={self.max_grad_norm}")
+            logging.info(f"Gradient clipping with max_norm={self.max_grad_norm}")
 
-        # Print initialization method
-        print(f"Using SAE initialization method: {self.initialization_method}")
+        # print  initialization method
+        logging.info(f"Using SAE initialization method: {self.initialization_method}")
 
         self.activation_fn_kwargs = self.activation_fn_kwargs or {}
 

--- a/src/vit_prisma/training/trainer.py
+++ b/src/vit_prisma/training/trainer.py
@@ -11,7 +11,7 @@ from vit_prisma.training.training_utils import (
 )
 from vit_prisma.utils.wandb_utils import dataclass_to_dict, update_dataclass_from_dict
 from vit_prisma.training.training_dictionary import optimizer_dict, loss_function_dict
-from vit_prisma.training.schedulers import WarmupThenStepLR
+from vit_prisma.training.schedulers import WarmupThenStepLR, WarmupCosineAnnealingLR
 from vit_prisma.training.early_stopping import EarlyStopping
 from vit_prisma.utils.saving_utils import save_config_to_file
 import os

--- a/src/vit_prisma/training/trainer.py
+++ b/src/vit_prisma/training/trainer.py
@@ -3,7 +3,12 @@ import torch
 import torch.optim as optim
 import tqdm
 from tqdm.auto import tqdm
-from vit_prisma.training.training_utils import calculate_accuracy, calculate_loss, set_seed, PrismaCallback
+from vit_prisma.training.training_utils import (
+    calculate_accuracy,
+    calculate_loss,
+    set_seed,
+    PrismaCallback,
+)
 from vit_prisma.utils.wandb_utils import dataclass_to_dict, update_dataclass_from_dict
 from vit_prisma.training.training_dictionary import optimizer_dict, loss_function_dict
 from vit_prisma.training.schedulers import WarmupThenStepLR
@@ -14,27 +19,30 @@ from torch.utils.data import Dataset, DataLoader
 import dataclasses
 from sklearn.model_selection import train_test_split
 
+
 def train(
-        model_function,
-        config,
-        train_dataset,
-        val_dataset=None,
-        checkpoint_path=None,
-        callbacks: list[PrismaCallback] = None
+    model_function,
+    config,
+    train_dataset,
+    val_dataset=None,
+    checkpoint_path=None,
+    callbacks: list[PrismaCallback] = None,
 ):
     if val_dataset is None:
         train_dataset, val_dataset = train_test_split(train_dataset, test_size=0.2)
-        print(f"Split train dataset into train and val with {len(train_dataset)} and {len(val_dataset)}.")
+        print(
+            f"Split train dataset into train and val with {len(train_dataset)} and {len(val_dataset)}."
+        )
 
     if config.use_wandb:
         if config.wandb_team_name is None:
             wandb.init(project=config.wandb_project_name)
         else:
             wandb.init(entity=config.wandb_team_name, project=config.wandb_project_name)
-        sweep_values = wandb.config._items # get sweep values
+        sweep_values = wandb.config._items  # get sweep values
         update_dataclass_from_dict(config, sweep_values)
         wandb.config.update(dataclass_to_dict(config))
-    
+
     print("Config is:", config)
     save_config_to_file(config, os.path.join(config.parent_dir, "config.json"))
 
@@ -42,11 +50,15 @@ def train(
     model = model_function(config)
     model.train()
     model.to(config.device)
-    optimizer = optimizer_dict[config.optimizer_name](model.parameters(), lr = config.lr, weight_decay = config.weight_decay)
+    optimizer = optimizer_dict[config.optimizer_name](
+        model.parameters(), lr=config.lr, weight_decay=config.weight_decay
+    )
     loss_fn = loss_function_dict[config.loss_fn_name]()
 
     if config.batch_size == -1:
-        batch_size_train, batch_size_test = len(train_dataset), len(val_dataset) # use full batch
+        batch_size_train, batch_size_test = len(train_dataset), len(
+            val_dataset
+        )  # use full batch
     else:
         batch_size_train, batch_size_test = config.batch_size, config.batch_size
 
@@ -58,28 +70,44 @@ def train(
     steps = 0
 
     if config.scheduler_type == "WarmupThenStepLR":
-        scheduler = WarmupThenStepLR(optimizer, warmup_steps=config.warmup_steps, step_size=config.scheduler_step, gamma=config.scheduler_gamma)
+        scheduler = WarmupThenStepLR(
+            optimizer,
+            warmup_steps=config.warmup_steps,
+            step_size=config.scheduler_step,
+            gamma=config.scheduler_gamma,
+        )
     elif config.scheduler_type == "CosineAnnealing":
-        scheduler = WarmupCosineAnnealingLR(optimizer, warmup_steps=config.warmup_steps, total_steps=int((config.num_epochs * len(train_dataset) / config.batch_size)))
+        scheduler = WarmupCosineAnnealingLR(
+            optimizer,
+            warmup_steps=config.warmup_steps,
+            total_steps=int(
+                (config.num_epochs * len(train_dataset) / config.batch_size)
+            ),
+        )
     else:
-        raise ValueError("Scheduler type {} not supported (only 'WarmupThenStep' and "
-                         "'CosineAnnealing'")
+        raise ValueError(
+            "Scheduler type {} not supported (only 'WarmupThenStep' and "
+            "'CosineAnnealing'"
+        )
 
     if config.early_stopping:
-        early_stopping = EarlyStopping(patience=config.early_stopping_patience, verbose=True)
-    else: 
+        early_stopping = EarlyStopping(
+            patience=config.early_stopping_patience, verbose=True
+        )
+    else:
         early_stopping = None
-    
-    if checkpoint_path and os.path.exists(checkpoint_path):
-        checkpoint = torch.load(checkpoint_path)
-        model.load_state_dict(checkpoint['model_state_dict'])
-        optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
-        start_epoch = checkpoint['epoch'] + 1
-        print(f"Loaded checkpoint from epoch {checkpoint['epoch']}")
-                
 
-    #create dir for checkoint if it doesn't exist
-    if os.path.exists(config.parent_dir) and not os.path.exists(os.path.join(config.parent_dir, config.save_dir)):
+    if checkpoint_path and os.path.exists(checkpoint_path):
+        checkpoint = torch.load(checkpoint_path, weights_only=False)
+        model.load_state_dict(checkpoint["model_state_dict"])
+        optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        start_epoch = checkpoint["epoch"] + 1
+        print(f"Loaded checkpoint from epoch {checkpoint['epoch']}")
+
+    # create dir for checkoint if it doesn't exist
+    if os.path.exists(config.parent_dir) and not os.path.exists(
+        os.path.join(config.parent_dir, config.save_dir)
+    ):
         os.makedirs(os.path.join(config.parent_dir, config.save_dir))
 
     num_samples = 0
@@ -96,18 +124,19 @@ def train(
                     "test_loss": test_loss,
                 }
                 if config.loss_fn_name == "MSE":
-                    tqdm.write(f"Steps{steps} | Train loss: {train_loss:.6f} | Test loss: {test_loss:.6f}")
+                    tqdm.write(
+                        f"Steps{steps} | Train loss: {train_loss:.6f} | Test loss: {test_loss:.6f}"
+                    )
                 else:
                     train_acc = calculate_accuracy(model, train_loader, config.device)
                     test_acc = calculate_accuracy(model, test_loader, config.device)
-                    tqdm.write(f"Steps{steps} | Train loss: {train_loss:.6f} | Train acc: {train_acc:.5f} | Test loss: {test_loss:.6f} | Test acc: {test_acc:.5f}")
-                    log_dict.update({
-                                        "train_acc": train_acc, 
-                                        "test_acc": test_acc
-                                     })
+                    tqdm.write(
+                        f"Steps{steps} | Train loss: {train_loss:.6f} | Train acc: {train_acc:.5f} | Test loss: {test_loss:.6f} | Test acc: {test_acc:.5f}"
+                    )
+                    log_dict.update({"train_acc": train_acc, "test_acc": test_acc})
                 if config.use_wandb:
-                    wandb.log(log_dict, step=num_samples) # Record number of samples
-                model.train() # set model back to train mode
+                    wandb.log(log_dict, step=num_samples)  # Record number of samples
+                model.train()  # set model back to train mode
 
             images, labels, *metadata = items
             images, labels = images.to(config.device), labels.to(config.device)
@@ -115,27 +144,47 @@ def train(
             optimizer.zero_grad()
 
             y = model(images)
-            
+
             loss = loss_fn(y, labels)
             loss.backward()
-            
-            torch.nn.utils.clip_grad_norm_(model.parameters(), config.max_grad_norm) if config.max_grad_norm is not None else None
-            
+
+            (
+                torch.nn.utils.clip_grad_norm_(model.parameters(), config.max_grad_norm)
+                if config.max_grad_norm is not None
+                else None
+            )
+
             optimizer.step()
             scheduler.step() if config.warmup_steps > 0 else None
-            
-            tqdm.write(f"Epoch {epoch} | steps{steps} | Num Samples {num_samples} | Loss {loss.item()}") if config.print_every and steps % config.print_every == 0 else None
-            
+
+            (
+                tqdm.write(
+                    f"Epoch {epoch} | steps{steps} | Num Samples {num_samples} | Loss {loss.item()}"
+                )
+                if config.print_every and steps % config.print_every == 0
+                else None
+            )
+
             if config.save_checkpoints and steps % config.save_cp_frequency == 0:
-                torch.save({
-                    'model_state_dict': model.state_dict(),
-                    'optimizer_state_dict': optimizer.state_dict(),
-                    'epoch': epoch
-                }, os.path.join(os.path.join(config.parent_dir, config.save_dir), f"model_{num_samples}.pth"))
-            
-            if hasattr(config, 'max_steps') and config.max_steps and steps >= config.max_steps:
+                torch.save(
+                    {
+                        "model_state_dict": model.state_dict(),
+                        "optimizer_state_dict": optimizer.state_dict(),
+                        "epoch": epoch,
+                    },
+                    os.path.join(
+                        os.path.join(config.parent_dir, config.save_dir),
+                        f"model_{num_samples}.pth",
+                    ),
+                )
+
+            if (
+                hasattr(config, "max_steps")
+                and config.max_steps
+                and steps >= config.max_steps
+            ):
                 break
-            
+
             steps += 1
             num_samples += len(labels)
             for callback in callbacks:


### PR DESCRIPTION

- **Merged `RunnerConfig` into `VisionModelSAERunnerConfig`**:  
  The `RunnerConfig` was removed, and its fields were merged into `VisionModelSAERunnerConfig` to address unclear separation between the two. This change simplifies the configuration structure.

- **Changed implicit fields to properties**:  
  Fields that were previously calculated implicitly are now defined as properties.  
  For example, `total_training_tokens` was originally defined as:  
  ```python
  total_training_tokens: int = total_training_images * context_size  # Images x tokens
  ```  
  This approach allowed inconsistent configurations, as `total_training_tokens` could be modified after initialization, violating algebraic consistency.  
  Now, it is defined as a property:  
  ```python
  @property
  def total_training_tokens(self):
      """Computes the total number of training tokens for the dataset and configuration."""
      if self.cls_token_only:  # Use only the CLS token per image
          tokens_per_image = 1
      elif self.use_patches_only:  # Exclude CLS token
          tokens_per_image = self.context_size - 1
      else:
          tokens_per_image = self.context_size

      return self.total_training_images * tokens_per_image
  ```  
  This change ensures consistency, improves maintainability, and makes the configuration easier to read.

- **Improved readability of configurations**:  
  By reducing redundancy and moving calculations into properties, the configuration structure is now more concise and easier to understand.

- **Replaced `print` statements with `logging.info`**:  
  Most `print` statements have been replaced with `logging.info`. This prevents the console from being flooded with unnecessary output when the program is not running in `info` mode, enabling better logging practices.