### PR TITLE
Setup git hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+    -   id: black
+        language_version: python3
+
+-   repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+    -   id: isort
+        args: ["--profile", "black", "--filter-files"]
+
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.2.1  # Replace with latest version
+    hooks:
+    -   id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+    -   id: ruff-format
+
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+    -   id: check-yaml
+    -   id: check-case-conflict

--- a/docs/UsageGuide.md
+++ b/docs/UsageGuide.md
@@ -120,4 +120,20 @@ The trainer has support for callbacks, that allows you to pass methods that can 
  trainer.train(model_function, config, train_dataset, callbacks=[DemoCallback()])
  ```
 
+## Git Hooks
 
+We have git hooks that run `ruff` (linter), `black` (code formatter), and `isort` (standardising imports), to improve maintainability of the code base.
+
+To set these up all you need to do is run:
+
+```
+pre-commit install 
+```
+
+Now every time you try to make a commit, the hooks will run automatically on your staged files.
+
+Further instructions:
+
+* To manually run the hooks on all files: `pre-commit run --all-files`
+* To manually run on staged files only: `pre-commit run`
+* To skip (not recommended) for a commit: `git commit -m "your message" --no-verify`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,49 @@
+
+[tool.ruff]
+line-length = 88
+
+
+force-exclude = true
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+]
+
+target-version = "py311"
+
+[tool.ruff.extend-per-file-ignores]
+"__init__.py" = ["E402", "F401"]
+
+[tool.ruff.lint]
+
+# Enable Pyflakes `E` and `F` codes by default.
+select = ["E", "F"]
+ignore = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+per-file-ignores = {}
+
+[tool.ruff.lint.mccabe]
+# Unlike Flake8, default to a complexity level of 10.
+max-complexity = 10

--- a/setup.py
+++ b/setup.py
@@ -1,53 +1,57 @@
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 install_requires = [
-    'pytest>=6.0',  # Test dependency, but included here to auto-install
-    'torch',        # Test dependency
-    'numpy',        # Test dependency
-    'jaxtyping',    # Test dependency
-    'einops',       # Test dependency
-    'fancy_einsum', # Test dependency
-    'plotly==5.19.0',
-    'timm',         # Test dependency
-    'transformers', # Test dependency
-    'scikit-learn', # Test dependency
-    'datasets',
-    'line_profiler',
-    'matplotlib',
-    'wandb',
-    'kaleido',
-    'open-clip-torch',
+    "datasets",
+    "einops",  # Test dependency
+    "fancy_einsum",  # Test dependency
+    "jaxtyping",  # Test dependency
+    "kaleido",
+    "line_profiler",
+    "matplotlib",
+    "numpy",  # Test dependency
+    "open-clip-torch",
+    "plotly==5.19.0",
+    "pytest>=6.0",  # Test dependency, but included here to auto-install
+    "pre-commit",
+    "scikit-learn",  # Test dependency
+    "timm",  # Test dependency
+    "torch",  # Test dependency
+    "transformers",  # Test dependency
+    "wandb",
 ]
 
 setup(
-    name='vit-prisma',
-    version='2.0.0',
-    author='Sonia Joseph',
-    author_email='soniamollyjoseph@gmail.com',
-    description='A Vision Transformer library for mechanistic interpretability.',
-    long_description=open('docs/README.md').read(),
-    long_description_content_type='text/markdown',
-    url='https://github.com/soniajoseph/vit-prisma',
-    packages=find_packages(where='src'),
-    package_dir={'': 'src'},
+    name="vit-prisma",
+    version="2.0.0",
+    author="Sonia Joseph",
+    author_email="soniamollyjoseph@gmail.com",
+    description="A Vision Transformer library for mechanistic interpretability.",
+    long_description=open("docs/README.md").read(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/soniajoseph/vit-prisma",
+    packages=find_packages(where="src"),
+    package_dir={"": "src"},
     package_data={
-    'vit_prisma': ['visualization/*.html', 'visualization/*.js'],
-    # Add other patterns here as needed
-},
+        "vit_prisma": ["visualization/*.html", "visualization/*.js"],
+        # Add other patterns here as needed
+    },
     classifiers=[
-        'Programming Language :: Python :: 3',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Intended Audience :: Science/Research',
-        'Topic :: Scientific/Engineering :: Artificial Intelligence',
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
-    python_requires='>=3.6',
+    python_requires=">=3.6",
     install_requires=install_requires,
-    keywords='vision-transformer, clip, multimodal, machine-learning, mechanistic interpretability',
+    keywords="vision-transformer, clip, multimodal, machine-learning, mechanistic "
+    "interpretability",
     zip_safe=False,
     extras_require={
-        'sae': ['sae-lens==2.1.3'],
-        'arrow': ['pyarrow']  # to use: pip install -e .[sae] # as of 2.1.3, windows will require pip install sae-lens==2.1.3 --no-dependencies followed by manually installing needed packages
+        "sae": ["sae-lens==2.1.3"],
+        "arrow": ["pyarrow"],
+        # to use: pip install -e .[sae] # as of 2.1.3, windows will requires:
+        # pip install sae-lens==2.1.3 --no-dependencies followed by manually installing
+        # needed packages
     },
 )


### PR DESCRIPTION
We have git hooks that run `ruff` (linter), `black` (code formatter), and `isort` (standardising imports), to improve maintainability of the code base.

To set these up all you need to do is run:

```
pre-commit install 
```

Now every time you try to make a commit, the hooks will run automatically on your staged files.

Further instructions:

* To manually run the hooks on all files: `pre-commit run --all-files`
* To manually run on staged files only: `pre-commit run`
* To skip (not recommended) for a commit: `git commit -m "your message" --no-verify`