### PR TITLE
🎨 improve model loading by moving the api calls to vit_prisma's __ini…

### DIFF
--- a/docs/UsageGuide.md
+++ b/docs/UsageGuide.md
@@ -37,7 +37,16 @@ config = HookedViTConfig()
 model = HookedViT(config)
 ```
 
-### Using pretrained models
+### Using pretrained model
+
+```python
+import vit_prisma
+model_name = "open-clip:timm/vit_base_patch32_clip_224.laion2b_e16"
+hooked_clip = vit_prisma.load_hooked_model(model_name)
+transform = vit_prisma.get_model_transforms(model_name)
+```
+
+### Using pretrained models (Legacy)
 
 ```python
 from vit_prisma.models.pretrained_model import PretrainedModel

--- a/src/vit_prisma/__init__.py
+++ b/src/vit_prisma/__init__.py
@@ -1,0 +1,32 @@
+from . import configs
+from . import dataloaders
+from . import model_eval
+from . import models
+from . import prisma_tools
+from . import sae
+from . import sample_images
+from . import training
+from . import transcoders
+from . import transforms
+from . import utils
+from . import visualization
+from . import vjepa_hf
+
+from .transforms.model_transforms import get_model_transforms
+from .models.model_loader import load_hooked_model
+
+__all__ = [
+    configs,
+    dataloaders,
+    model_eval,
+    models,
+    prisma_tools,
+    sae,
+    sample_images,
+    training,
+    transcoders,
+    transforms,
+    utils,
+    visualization,
+    vjepa_hf,
+]


### PR DESCRIPTION
Changed the `__init__.py` so that loading model and transform are top level calls, reducing the entry barrier of using the lib. Updated the docs.

```python 
import vit_prisma
model_name = "open-clip:timm/vit_base_patch32_clip_224.laion2b_e16"
hooked_clip = vit_prisma.load_hooked_model(model_name).cuda()
transform = vit_prisma.get_model_transforms(model_name)
```