### PR TITLE
Evaluate with clip_benchmark

### DIFF
--- a/src/vit_prisma/model_eval/README.md
+++ b/src/vit_prisma/model_eval/README.md
@@ -1,0 +1,206 @@
+# ViT-Prisma Model Evaluation
+
+This directory contains evaluation scripts for ViT-Prisma models, including both ImageNet evaluation and comprehensive CLIP benchmark evaluation.
+
+## Files
+
+- `evaluate_imagenet.py` - ImageNet zero-shot evaluation for ViT-Prisma models
+- `evaluate_clip_benchmark.py` - Comprehensive evaluation using CLIP benchmark datasets
+- `clip_benchmark_tasks.yml` - Configuration file defining evaluation tasks and datasets
+
+## CLIP Benchmark Evaluation
+
+The `evaluate_clip_benchmark.py` script provides comprehensive evaluation of ViT-Prisma models using the CLIP benchmark framework. It leverages the existing `eval_utils` infrastructure from DataComp, modified to support ViT-Prisma's model loading system.
+
+### Usage
+
+#### Basic Usage
+
+Evaluate a pretrained open-clip model on default tasks in clip_benchmark_tasks.yml:
+
+```bash
+python evaluate_clip_benchmark.py --model_name "open-clip:laion/CLIP-ViT-B-32-laion2B-s34B-b79K"
+```
+
+Evaluate a pretrained open-clip model on a single task in clip_benchmark_tasks.yml:
+
+```bash
+python evaluate_clip_benchmark.py \
+    --model_name "open-clip:laion/CLIP-ViT-B-32-laion2B-s34B-b79K" \
+    --task "cifar10"
+```
+
+Evaluate a pretrained open-clip model with Prisma sae (downloaded to local disk):
+
+```bash
+python evaluate_clip_benchmark.py \
+    --model_name "open-clip:laion/CLIP-ViT-B-32-laion2B-s34B-b79K" \
+    --task "cifar10" \
+    --sae_path "/path/to/downloaded/sae/sae_l11_resid/weights.pt"
+```
+
+#### Custom Checkpoint
+
+Evaluate a local checkpoint, it could be a downloaded pretrained open-clip model or finetuned open-clip model:
+
+```bash
+python evaluate_clip_benchmark.py \
+    --model_name "open-clip:laion/CLIP-ViT-B-32-laion2B-s34B-b79K" \
+    --checkpoint_path "/path/to/your/checkpoint.pt"
+```
+
+#### On downloaded benchmark testset data
+
+There are cases you may want to evaluate on the pre-downloaded benchmark testset data. It can be done by:
+
+```bash
+python evaluate_clip_benchmark.py \
+    --model_name "open-clip:laion/CLIP-ViT-B-32-laion2B-s34B-b79K" \
+    --data_root "/path/to/datasets/datacomp_eval_data"
+```
+
+You can use [this script from datacomp repo](https://github.com/mlfoundations/datacomp?tab=readme-ov-file#optional-pre-download-evaluation-datasets) to download the testset data.
+
+
+#### Full Configuration Example
+
+```bash
+python evaluate_clip_benchmark.py \
+    --model_name "open-clip:laion/CLIP-ViT-B-32-laion2B-s34B-b79K" \
+    --checkpoint_path "/path/to/your/models/clip_B_32_Laion/open_clip_pytorch_model.bin" \
+    --tasks_config "clip_benchmark_tasks.yml" \
+    --data_root "/path/to/datasets/datacomp_eval_data" \
+    --output_dir "./results" \
+    --sae_path "/path/to/downloaded/sae/sae_l11_resid/weights.pt" \
+    --batch_size 128
+```
+
+### Command Line Arguments
+
+#### Model Arguments
+- `--model_name`: Name of the ViT-Prisma model to evaluate (required)
+- `--checkpoint_path`: Path to model checkpoint (optional)
+
+#### Data Arguments
+- `--data_root`: Root directory for evaluation datasets
+- `--tasks_config`: Path to YAML file containing task configurations
+
+#### Evaluation Arguments
+- `--batch_size`: Batch size for evaluation (default: 64)
+- `--device`: Device to run evaluation on (default: "cuda")
+- `--dtype`: Data type for model parameters (choices: "float32", "float16", "bfloat16")
+
+#### Output Arguments
+- `--output_dir`: Directory to save evaluation results
+- `--num_workers`: Number of data loading workers (default: 8)
+
+### Task Configuration
+
+The `clip_benchmark_tasks.yml` file defines the evaluation tasks. Each task includes:
+
+```yaml
+imagenet1k:
+  name: ImageNet 1k
+  size: 50000
+  main_metric: acc1
+  num_classes: 1000
+  tags: []
+```
+
+- `name`: Human-readable name for the dataset
+- `size`: Number of samples in the test set
+- `main_metric`: Primary metric to report (e.g., acc1, mean_per_class_recall)
+- `num_classes`: Number of classes in the dataset
+- `tags`: Categories for grouping datasets
+
+### Supported Datasets
+
+The evaluation supports 40+ datasets across multiple categories:
+
+#### Core Vision Tasks
+- ImageNet variants (ImageNet-1k, ImageNet-v2, ImageNet-A/R/O, ImageNet Sketch)
+- CIFAR-10/100
+
+#### Fine-grained Classification
+- FGVC Aircraft, Stanford Cars, Food-101
+- Oxford Flowers-102, Oxford-IIIT Pet
+- Caltech-101
+
+#### Specialized Domains
+- EuroSAT (satellite imagery)
+- PatchCamelyon (medical imaging)
+- RESISC45 (remote sensing)
+
+#### Texture and Scene Recognition
+- Describable Textures (DTD)
+- SUN397 (scene understanding)
+
+#### Structured Reasoning
+- CLEVR (visual reasoning)
+- KITTI (autonomous driving)
+
+#### Retrieval Tasks
+- Flickr30k, MS-COCO (image-text retrieval)
+
+### Output Format
+
+Results are saved in JSONL format with one result per line:
+
+```json
+{
+  "key": "imagenet1k",
+  "dataset": "ImageNet 1k",
+  "metrics": {
+    "acc1": 0.7234,
+    "acc5": 0.9123,
+    "mean_per_class_recall": 0.7156,
+    "main_metric": 0.7234,
+    "l0": 0.0,
+    "l1": 12.34,
+    "l2": 45.67
+  }
+}
+```
+
+
+### Comparison with DataComp
+
+This implementation is based on [DataComp](https://github.com/mlfoundations/datacomp)'s evaluation system but adapted for ViT-Prisma:
+
+- **Model Loading**: Uses ViT-Prisma's model loader instead of OpenCLIP
+- **Architecture Support**: Supports ViT-Prisma's hooked models
+
+### Requirements
+
+- `clip_benchmark`: For dataset loading and evaluation metrics
+- `torch`: PyTorch framework
+- `torchvision`: For image transforms
+- `sklearn`: For additional metrics
+- `numpy`: For numerical operations
+- `tqdm`: For progress bars
+- `pyyaml`: For configuration files
+
+### Example Results
+
+After evaluation, you'll see output like:
+
+```
+Evaluating model openai/clip-vit-base-patch32 on 3 tasks...
+
+Evaluating on ImageNet 1k
+Score: 0.7234
+
+Evaluating on CIFAR-10
+Score: 0.9456
+
+Evaluating on CIFAR-100
+Score: 0.7891
+
+Evaluation completed in 0h 45m 23s
+
+=== Final Results ===
+ImageNet 1k: 0.7234
+CIFAR-10: 0.9456
+CIFAR-100: 0.7891
+Average: 0.8194
+```

--- a/src/vit_prisma/model_eval/clip_benchmark_tasks.yml
+++ b/src/vit_prisma/model_eval/clip_benchmark_tasks.yml
@@ -1,0 +1,253 @@
+---
+# CLIP Benchmark Task Configuration for ViT-Prisma
+# Based on datacomp tasklist.yml but only keeping the wds and retrieval tasks
+
+# Core Vision Tasks
+
+# ImageNet variants
+imagenet1k:
+  name: ImageNet 1k
+  size: 50000
+  main_metric: acc1
+  num_classes: 1000
+  tags: []
+
+imagenetv2:
+  name: ImageNet v2
+  size: 10000
+  main_metric: acc1
+  num_classes: 1000
+  tags: []
+
+imagenet_sketch:
+  name: ImageNet Sketch
+  size: 50889
+  main_metric: acc1
+  num_classes: 1000
+  tags: []
+
+imagenet-a:
+  name: ImageNet-A
+  size: 7500
+  main_metric: acc1
+  num_classes: 200
+  tags: []
+
+imagenet-r:
+  name: ImageNet-R
+  size: 30000
+  main_metric: acc1
+  num_classes: 200
+  tags: []
+
+imagenet-o:
+  name: ImageNet-O
+  size: 2000
+  main_metric: acc1
+  num_classes: 200
+  tags: []
+
+# CIFAR datasets
+cifar10:
+  name: CIFAR-10
+  size: 10000
+  main_metric: acc1
+  num_classes: 10
+  tags: []
+
+vtab/cifar100:
+  name: CIFAR-100
+  size: 10000
+  main_metric: acc1
+  num_classes: 100
+  tags:
+    - vtab_natural
+
+# Fine-grained classification
+vtab/caltech101:
+  name: Caltech-101
+  size: 6085
+  main_metric: mean_per_class_recall
+  num_classes: 102
+  tags:
+    - vtab_natural
+
+fgvc_aircraft:
+  name: FGVC Aircraft
+  size: 3333
+  main_metric: mean_per_class_recall
+  num_classes: 100
+  tags: []
+
+cars:
+  name: Stanford Cars
+  size: 8041
+  main_metric: acc1
+  num_classes: 196
+  tags: []
+
+food101:
+  name: Food-101
+  size: 25250
+  main_metric: acc1
+  num_classes: 101
+  tags: []
+
+vtab/flowers:
+  name: Oxford Flowers-102
+  size: 6149
+  main_metric: mean_per_class_recall
+  num_classes: 102
+  tags:
+    - vtab_natural
+
+vtab/pets:
+  name: Oxford-IIIT Pet
+  size: 3669
+  main_metric: mean_per_class_recall
+  num_classes: 37
+  tags:
+    - vtab_natural
+
+# Texture and scene recognition
+vtab/dtd:
+  name: Describable Textures
+  size: 1880
+  main_metric: acc1
+  num_classes: 47
+  tags:
+    - vtab_natural
+
+sun397:
+  name: SUN397
+  size: 108754
+  main_metric: acc1
+  num_classes: 397
+  tags:
+    - vtab_natural
+
+# Specialized domains
+vtab/eurosat:
+  name: EuroSAT
+  size: 5400
+  main_metric: acc1
+  num_classes: 10
+  tags:
+    - vtab_specialized
+
+vtab/resisc45:
+  name: RESISC45
+  size: 6300
+  main_metric: acc1
+  num_classes: 45
+  tags:
+    - vtab_specialized
+
+vtab/pcam:
+  name: PatchCamelyon
+  size: 32768
+  main_metric: acc1
+  num_classes: 2
+  tags:
+    - vtab_specialized
+
+# Geographic and cultural
+country211:
+  name: Country211
+  size: 21100
+  main_metric: acc1
+  num_classes: 211
+  tags: []
+
+# Other datasets
+mnist:
+  name: MNIST
+  size: 10000
+  main_metric: acc1
+  num_classes: 10
+  tags: []
+
+stl10:
+  name: STL-10
+  size: 8000
+  main_metric: acc1
+  num_classes: 10
+  tags: []
+
+vtab/svhn:
+  name: SVHN
+  size: 26032
+  main_metric: acc1
+  num_classes: 10
+  tags:
+    - vtab_natural
+
+gtsrb:
+  name: GTSRB
+  size: 12630
+  main_metric: acc1
+  num_classes: 43
+  tags: []
+
+objectnet:
+  name: ObjectNet
+  size: 18574
+  main_metric: acc1
+  num_classes: 113
+  tags: []
+
+voc2007:
+  name: Pascal VOC 2007
+  size: 14976
+  main_metric: acc1
+  num_classes: 20
+  tags: []
+
+renderedsst2:
+  name: Rendered SST2
+  size: 1821
+  main_metric: acc1
+  num_classes: 2
+  tags: []
+
+# Structured reasoning tasks
+vtab/clevr_count_all:
+  name: CLEVR Counts
+  size: 15000
+  main_metric: acc1
+  num_classes: 8
+  tags:
+    - vtab_structured
+
+vtab/clevr_closest_object_distance:
+  name: CLEVR Distance
+  size: 15000
+  main_metric: acc1
+  num_classes: 6
+  tags:
+    - vtab_structured
+
+vtab/kitti_closest_vehicle_distance:
+  name: KITTI Vehicle Distance
+  size: 711
+  main_metric: acc1
+  num_classes: 4
+  tags:
+    - vtab_structured
+
+# Retrieval tasks (if supported)
+retrieval/flickr_1k_test_image_text_retrieval:
+  name: Flickr
+  size: 1000
+  main_metric: mean_recall@1
+  tags:
+    - retrieval
+
+retrieval/mscoco_2014_5k_test_image_text_retrieval:
+  name: MSCOCO
+  size: 5000
+  main_metric: mean_recall@1
+  tags:
+    - retrieval
+
+...

--- a/src/vit_prisma/model_eval/eval_utils/main.py
+++ b/src/vit_prisma/model_eval/eval_utils/main.py
@@ -1,0 +1,40 @@
+# Main branching point for evaluating on different datasets
+
+from .retr_eval import evaluate_retrieval_dataset
+from .wds_eval import evaluate_webdataset
+
+
+def evaluate_model(
+    task_key,
+    train_info,
+    data_root=None,
+    dataset_size=None,
+    batch_size=64,
+    sae_path=None,
+):
+    # Extract model_kwargs from train_info if available (for SAE models)
+    model_kwargs = train_info.get("model_kwargs", {})
+
+    if task_key.startswith("retrieval/"):
+        # Note: retr_eval uses create_model from wds_eval, which already supports model_kwargs
+        metrics = evaluate_retrieval_dataset(
+            task_key,
+            train_info["scale_config"]["model"],
+            train_info["checkpoint"],
+            data_root=data_root,
+            batch_size=batch_size,
+            model_kwargs=model_kwargs,
+            sae_path=sae_path,
+        )
+    else:
+        metrics = evaluate_webdataset(
+            task_key,
+            train_info["scale_config"]["model"],
+            train_info["checkpoint"],
+            data_root=data_root,
+            dataset_len=dataset_size,
+            batch_size=batch_size,
+            model_kwargs=model_kwargs,
+            sae_path=sae_path,
+        )
+    return metrics

--- a/src/vit_prisma/model_eval/eval_utils/retr_eval.py
+++ b/src/vit_prisma/model_eval/eval_utils/retr_eval.py
@@ -1,0 +1,79 @@
+"""Evaluate on image-text retrieval datasets."""
+
+import os
+
+import datasets
+import open_clip
+import torch
+from clip_benchmark.datasets.builder import image_captions_collate_fn
+from clip_benchmark.metrics import zeroshot_retrieval as zsr
+
+from .wds_eval import create_model_for_prisma, get_text_tokenizer
+
+
+class RetrievalDataset(torch.utils.data.Dataset):
+    def __init__(self, hf_dataset, transform=None):
+        super().__init__()
+        self._dataset = hf_dataset
+        self.transform = (lambda x: x) if transform is None else transform
+
+    def __len__(self):
+        return len(self._dataset)
+
+    def __getitem__(self, index: int):
+        return (
+            self.transform(self._dataset[index]["image"]),
+            self._dataset[index]["caption"],
+        )
+
+
+def evaluate_retrieval_dataset(
+    task,
+    model_arch,
+    model_path,
+    data_root=None,
+    batch_size=64,
+    num_workers=4,
+    model_kwargs=None,
+    sae_path=None,
+):
+    """Evaluate CLIP model on retrieval task."""
+
+    model, transform, device = create_model_for_prisma(
+        model_arch,
+        model_path,
+        model_kwargs,
+        sae_path=sae_path,
+    )
+
+    # Get appropriate tokenizer
+    # tokenizer = open_clip.get_tokenizer(model_arch)
+
+    dataset = RetrievalDataset(
+        datasets.load_dataset(
+            f"nlphuji/{task.replace('retrieval/', '')}",
+            split="test",
+            cache_dir=(
+                os.path.join(data_root, "hf_cache") if data_root is not None else None
+            ),
+        ),
+        transform=transform,
+    )
+    dataloader = torch.utils.data.DataLoader(
+        dataset,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        collate_fn=image_captions_collate_fn,
+    )
+
+    local_path = model_path if os.path.exists(model_path) else None
+    tokenizer = get_text_tokenizer(model_arch, local_path=local_path)
+
+    metrics = zsr.evaluate(
+        model, dataloader, tokenizer, recall_k_list=[1, 5, 10], device=device
+    )
+    metrics["mean_recall@1"] = 0.5 * (
+        metrics["text_retrieval_recall@1"] + metrics["image_retrieval_recall@1"]
+    )
+    return metrics

--- a/src/vit_prisma/model_eval/eval_utils/wds_eval.py
+++ b/src/vit_prisma/model_eval/eval_utils/wds_eval.py
@@ -1,0 +1,390 @@
+"""Evaluate on standard classification webdatasets."""
+
+import logging
+import os
+
+import open_clip
+import torch
+from clip_benchmark.datasets.builder import build_dataset
+from clip_benchmark.metrics import zeroshot_classification as zsc
+from sklearn.metrics import balanced_accuracy_score
+from vit_prisma.models.model_loader import _get_open_clip_config, load_hooked_model
+from vit_prisma.models.weight_conversion import remove_open_clip_prefix
+from vit_prisma.utils.enums import ModelType
+
+
+# Suppress PIL debug logs
+logging.getLogger("PIL").setLevel(logging.WARNING)
+logging.getLogger("PIL.Image").setLevel(logging.WARNING)
+logging.getLogger("PIL.PngImagePlugin").setLevel(logging.WARNING)
+logging.getLogger("PIL.TiffImagePlugin").setLevel(logging.WARNING)
+
+
+# create the wrapper model using open_clip and sae
+def create_model_for_prisma(model_arch, model_path, model_kwargs=None, sae_path=None):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    torch.manual_seed(0)
+
+    model_path = str(model_path)
+
+    if model_kwargs is None:
+        model_kwargs = {}
+
+    # Check if model_path is a local checkpoint
+    if os.path.exists(model_path):
+        # Load from local checkpoint with local_path parameter
+        model = load_hooked_model(
+            model_name=model_arch,
+            model_type=ModelType.VISION,
+            device=device,
+            pretrained=True,
+            local_path=model_path,
+            **model_kwargs,
+        )
+    else:
+        # Load pretrained model
+        model = load_hooked_model(
+            model_name=model_arch,
+            model_type=ModelType.VISION,
+            device=device,
+            pretrained=True,
+            **model_kwargs,
+        )
+
+    # Ensure the ViT-Prisma model is properly moved to device
+    model = model.to(device)
+    model.eval()
+
+    # Also load the original OpenCLIP model for text encoding
+    text_encoder = None
+    if os.path.exists(model_path):
+        # Load from local checkpoint with local_path parameter
+        text_encoder = load_hooked_model(
+            model_name=model_arch,
+            model_type=ModelType.TEXT,
+            device=device,
+            pretrained=True,
+            local_path=model_path,
+            **model_kwargs,
+        )
+    else:
+        # Load pretrained model
+        text_encoder = load_hooked_model(
+            model_name=model_arch,
+            model_type=ModelType.TEXT,
+            device=device,
+            pretrained=True,
+            **model_kwargs,
+        )
+
+    text_encoder.eval()
+    text_encoder = text_encoder.to(device)
+    print("Loaded original OpenCLIP model for text encoding")
+
+    # Load and integrate SAE if provided
+    if sae_path and os.path.exists(sae_path):
+        print(f"Loading SAE from: {sae_path}")
+        from vit_prisma.sae.sae import SparseAutoencoder
+
+        # Load SAE
+        sae = SparseAutoencoder.load_from_pretrained(weights_path=sae_path)
+        sae.to(device)
+        sae.eval()
+
+        print(f"SAE loaded successfully:")
+        print(f"  Hook point: {sae.cfg.hook_point}")
+        print(f"  Dimensions: d_in={sae.cfg.d_in}, d_sae={sae.cfg.d_sae}")
+        print(f"  Architecture: {sae.cfg.architecture}")
+
+        # Create a wrapper model that integrates CLIP with SAE
+        model = CLIPWithSAEWrapper(model, sae, sae.cfg.hook_point, text_encoder)
+        print("CLIP model integrated with SAE")
+    elif text_encoder is not None:
+        # Even without SAE, wrap the model so it's still functional
+        model = CLIPWithSAEWrapper(model, None, None, text_encoder)
+        print("ViT-Prisma model wrapped with OpenCLIP for text encoding")
+
+    # Ensure the wrapper is properly moved to device
+    model = model.to(device)
+
+    # Get transform - try to use model's transform if available
+    if hasattr(model, "transform"):
+        transform = model.transform
+    else:
+        # Fallback to standard transform
+        from torchvision import transforms
+
+        class GrayscaleToRGB:
+            """Convert grayscale images to RGB by repeating the channel 3 times."""
+
+            def __call__(self, tensor):
+                if tensor.shape[0] == 1:  # Grayscale image
+                    return tensor.repeat(3, 1, 1)
+                return tensor
+
+        transform = transforms.Compose(
+            [
+                transforms.Resize(224),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                GrayscaleToRGB(),  # Convert grayscale to RGB
+                transforms.Normalize(
+                    mean=[0.48145466, 0.4578275, 0.40821073],
+                    std=[0.26862954, 0.26130258, 0.27577711],
+                ),
+            ]
+        )
+
+    return model, transform, device
+
+
+class CLIPWithSAEWrapper(torch.nn.Module):
+    """Wrapper class that integrates CLIP model with SAE."""
+
+    def __init__(self, vision_encoder, sae, hook_point, text_encoder):
+        super().__init__()
+        self.vision_encoder = vision_encoder
+        self.sae = sae
+        self.hook_point = hook_point
+        self.use_sae = True
+        self._hook_handle = None
+        self.text_encoder = text_encoder  # For text encoding
+
+        # Register the hook once during initialization for evaluation
+        self._register_hook()
+
+    def _find_module_by_name(self, model, target_name):
+        """Find a module by its name in the model hierarchy."""
+        for name, module in model.named_modules():
+            if name == target_name:
+                return module
+        return None
+
+    def _sae_hook_fn(self, module, input, output):
+        """Hook function that applies SAE to the activations."""
+        if self.use_sae and self.sae is not None:
+            # Apply SAE to the output activations
+            sae_out, feature_acts = self.sae.encode(output)
+            return self.sae.decode(feature_acts)
+        return output
+
+    def _register_hook(self):
+        """Register the SAE hook on the target module."""
+        if self._hook_handle is not None:
+            return  # Hook already registered
+
+        # Skip hook registration if no SAE or hook point
+        if self.sae is None or self.hook_point is None:
+            print("No SAE or hook point specified, skipping hook registration")
+            return
+
+        target_module = self._find_module_by_name(self.vision_encoder, self.hook_point)
+        if target_module is None:
+            print(f"Warning: Could not find module '{self.hook_point}' in the model")
+            print("Available modules:")
+            for name, _ in self.vision_encoder.named_modules():
+                if "block" in name.lower() or "layer" in name.lower():
+                    print(f"  {name}")
+            return
+
+        self._hook_handle = target_module.register_forward_hook(self._sae_hook_fn)
+        print(f"SAE hook registered at: {self.hook_point}")
+
+    def _remove_hook(self):
+        """Remove the registered hook."""
+        if self._hook_handle is not None:
+            self._hook_handle.remove()
+            self._hook_handle = None
+
+    def forward(self, x):
+        # Hook is already registered, just do forward pass
+        return self.vision_encoder(x)
+
+    def encode_image(self, images, normalize=True):
+        # Use forward pass with SAE (hook is already active)
+        features = self.forward(images)
+
+        if normalize:
+            features = torch.nn.functional.normalize(features, dim=-1)
+        return features
+
+    def encode_text(self, text, normalize=True):
+        features = self.text_encoder(text)
+
+        if normalize:
+            features = torch.nn.functional.normalize(features, dim=-1)
+        return features
+
+    def to(self, device):
+        self.vision_encoder = self.vision_encoder.to(device)
+        self.text_encoder = self.text_encoder.to(device)
+        if self.sae is not None:
+            self.sae = self.sae.to(device)
+        return self
+
+    def eval(self):
+        self.vision_encoder.eval()
+        self.text_encoder.eval()
+        if self.sae is not None:
+            self.sae.eval()
+        return self
+
+    def train(self, mode=True):
+        raise NotImplementedError("CLIPWithSAEWrapper is for evaluation only.")
+
+    def __del__(self):
+        """Cleanup hook when object is destroyed."""
+        self._remove_hook()
+
+
+def get_text_tokenizer(
+    model_name: str,
+    local_path: str = None,
+    **kwargs,
+):
+
+    if local_path:
+        # Load the raw config dictionary instead of the processed HookedViTConfig
+        old_config = _get_open_clip_config(
+            model_name, ModelType.VISION, local_path=local_path
+        )
+
+        text_config = old_config.get("text_cfg", {})
+        if "tokenizer_kwargs" in text_config:
+            tokenizer_kwargs = dict(text_config["tokenizer_kwargs"], **kwargs)
+        else:
+            tokenizer_kwargs = kwargs
+
+        DEFAULT_CONTEXT_LENGTH = 77
+        context_length = text_config.get("context_length", DEFAULT_CONTEXT_LENGTH)
+
+        model_name = model_name.lower()
+        if text_config.get("hf_tokenizer_name", ""):
+            raise NotImplementedError
+        elif "siglip" in model_name:
+            raise NotImplementedError
+        else:
+            from open_clip.tokenizer import SimpleTokenizer
+
+            # TODO: currently all Prisma pretrained openCLIP SAEs use the same text tokenizer, so this is fine
+            # need to be fixed if eval on new models with different tokenizers
+            tokenizer = SimpleTokenizer(
+                context_length=context_length,
+                **tokenizer_kwargs,
+            )
+    else:
+        import open_clip
+
+        # TODO: currently all Prisma pretrained openCLIP SAEs use the same text tokenizer, so this is fine
+        # need to be fixed if eval on new models with different tokenizers
+        tokenizer = open_clip.get_tokenizer("ViT-B-32")
+
+    return tokenizer
+
+
+def create_webdataset(
+    task, transform, data_root=None, dataset_len=None, batch_size=64, num_workers=4
+):
+    data_folder = f"wds_{task.replace('/','-')}_test"
+    if data_root is None:
+        data_root = f"https://huggingface.co/datasets/djghosh/{data_folder}/tree/main"
+    else:
+        data_root = os.path.join(data_root, data_folder)
+    dataset = build_dataset(
+        dataset_name=f"wds/{task}",
+        root=data_root,
+        transform=transform,
+        split="test",
+        download=False,
+    )
+    if dataset_len:
+        dataset = dataset.with_length((dataset_len + batch_size - 1) // batch_size)
+    dataloader = torch.utils.data.DataLoader(
+        dataset.batched(batch_size),
+        batch_size=None,
+        shuffle=False,
+        num_workers=num_workers,
+    )
+    return dataset, dataloader
+
+
+def evaluate_webdataset(
+    task,
+    model_arch,
+    model_path,
+    data_root=None,
+    dataset_len=None,
+    batch_size=64,
+    num_workers=8,
+    return_preds=False,
+    return_topk=False,
+    model_kwargs=None,
+    use_vit_prisma=False,
+    sae_path=None,
+):
+    """Evaluate CLIP model on classification task."""
+
+    # Create model
+    model, transform, device = create_model_for_prisma(
+        model_arch,
+        model_path,
+        model_kwargs,
+        sae_path=sae_path,
+    )
+
+    # Load data
+    dataset, dataloader = create_webdataset(
+        task, transform, data_root, dataset_len, batch_size, num_workers
+    )
+
+    zeroshot_templates = dataset.templates if hasattr(dataset, "templates") else None
+    classnames = dataset.classes if hasattr(dataset, "classes") else None
+    assert (
+        zeroshot_templates is not None and classnames is not None
+    ), "Dataset does not support classification"
+
+    # Evaluate
+    # Get appropriate tokenizer
+
+    local_path = model_path if os.path.exists(model_path) else None
+    tokenizer = get_text_tokenizer(model_arch, local_path=local_path)
+
+    classifier = zsc.zero_shot_classifier(
+        model,
+        tokenizer,
+        classnames,
+        zeroshot_templates,
+        device,
+    )
+    logits, target, l0, l1, l2 = zsc.run_classification(
+        model, classifier, dataloader, device, amp=False
+    )
+    with torch.no_grad():
+        pred = logits.argmax(axis=1).cpu()
+        target = target.cpu()
+
+    # Compute metrics
+    if len(dataset.classes) >= 5:
+        acc1, acc5 = zsc.accuracy(logits, target, topk=(1, 5))
+    else:
+        (acc1,) = zsc.accuracy(logits, target, topk=(1,))
+        acc5 = None
+    mean_per_class_recall = balanced_accuracy_score(target, pred)
+
+    metrics = {
+        "acc1": acc1,
+        "acc5": acc5,
+        "mean_per_class_recall": mean_per_class_recall,
+        "l0": l0.mean().numpy().item(),
+        "l1": l1.mean().numpy().item(),
+        "l2": l2.mean().numpy().item(),
+    }
+
+    if return_preds:
+        if return_topk:
+            with torch.no_grad():
+                _, topk_pred = torch.topk(logits, int(return_topk), dim=1)
+                topk_pred = topk_pred.cpu()
+            return metrics, topk_pred, target
+        return metrics, pred, target
+    return metrics

--- a/src/vit_prisma/model_eval/evaluate_clip_benchmark.py
+++ b/src/vit_prisma/model_eval/evaluate_clip_benchmark.py
@@ -1,0 +1,340 @@
+"""
+CLIP Benchmark Evaluation for ViT-Prisma Models
+===============================================
+
+This module provides clip_benchmark based evaluation for ViT-Prisma models,
+using the existing eval_utils infrastructure from datacomp but adapted for 
+ViT-Prisma's model architecture and loading system.
+"""
+
+import argparse
+import json
+import logging
+import os
+import pickle
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+# Add the src directory to Python path to find vit_prisma module
+current_file = Path(__file__).resolve()
+src_dir = current_file.parent.parent.parent  # Go up to src directory
+if str(src_dir) not in sys.path:
+    sys.path.insert(0, str(src_dir))
+
+import numpy as np
+import torch
+import yaml
+
+# Import the evaluation utilities
+from eval_utils.main import evaluate_model
+from tqdm import tqdm
+
+
+def create_train_info(
+    model_name: str,
+    checkpoint_path: Optional[str] = None,
+    model_kwargs: Optional[Dict] = None,
+) -> Dict[str, Any]:
+    """
+    Create a train_info dictionary compatible with the eval_utils infrastructure.
+
+    Args:
+        model_name: Name of the ViT-Prisma model
+        checkpoint_path: Optional path to model checkpoint
+        model_kwargs: Optional additional model arguments
+
+    Returns:
+        Dictionary containing training information in the expected format
+    """
+    if model_kwargs is None:
+        model_kwargs = {}
+
+    # Create a minimal train_info structure that matches datacomp's format
+    train_info = {
+        "scale_config": {
+            "model": model_name,
+        },
+        "checkpoint": checkpoint_path if checkpoint_path else model_name,
+        "model_kwargs": model_kwargs,
+    }
+
+    return train_info
+
+
+def evaluate_vit_prisma_model(
+    model_name: str,
+    checkpoint_path: Optional[str] = None,
+    tasks_config: Union[str, Dict] = None,
+    data_root: Optional[str] = None,
+    output_dir: Optional[str] = None,
+    batch_size: int = 64,
+    model_kwargs: Optional[Dict] = None,
+    sae_path: Optional[str] = None,
+    **kwargs,
+) -> Dict[str, Dict[str, Any]]:
+    """
+    Evaluate a ViT-Prisma model on multiple tasks using the eval_utils infrastructure.
+
+    Args:
+        model_name: Name of the ViT-Prisma model
+        checkpoint_path: Optional path to model checkpoint
+        tasks_config: Path to tasks YAML file or dictionary of tasks
+        data_root: Root directory for datasets
+        output_dir: Directory to save results
+        batch_size: Batch size for evaluation
+        model_kwargs: Optional additional model arguments
+        sae_path: Optional path to SAE weights
+        **kwargs: Additional arguments
+
+    Returns:
+        Dictionary containing results for all tasks
+    """
+    # Load tasks configuration
+    if isinstance(tasks_config, str):
+        with open(tasks_config, "r") as f:
+            tasks = yaml.safe_load(f)
+    elif isinstance(tasks_config, dict):
+        tasks = tasks_config
+    else:
+        # Use default tasks similar to datacomp
+        tasks = {
+            "imagenet1k": {"name": "ImageNet 1k", "main_metric": "acc1"},
+            "cifar10": {"name": "CIFAR-10", "main_metric": "acc1"},
+            "vtab/cifar100": {"name": "CIFAR-100", "main_metric": "acc1"},
+        }
+
+    # Create train_info structure
+    train_info = create_train_info(model_name, checkpoint_path, model_kwargs)
+
+    results = {}
+    start_time = time.time()
+
+    # Create output directory if specified
+    if output_dir:
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        results_file = output_dir / "eval_results.jsonl"
+
+        # Save train_info for reference
+        info_file = output_dir / "info.pkl"
+        with open(info_file, "wb") as f:
+            pickle.dump(train_info, f)
+    else:
+        results_file = None
+
+    print(f"Evaluating ViT-Prisma model {model_name} on {len(tasks)} tasks...")
+
+    for task_key in tqdm(tasks, desc="Evaluating tasks"):
+        task_info = tasks[task_key]
+        task_name = task_info.get("name", task_key)
+
+        print(f"\nEvaluating on {task_name}")
+
+        # Use the eval_utils infrastructure with ViT-Prisma flag
+        metrics = evaluate_model(
+            task_key=task_key,
+            train_info=train_info,
+            data_root=data_root,
+            dataset_size=task_info.get("size"),
+            batch_size=batch_size,
+            sae_path=sae_path,
+        )
+
+        # Get main metric
+        main_metric_key = task_info.get("main_metric", "acc1")
+        metrics["main_metric"] = metrics.get(main_metric_key)
+
+        result = {
+            "key": task_key,
+            "dataset": task_name,
+            "metrics": metrics,
+        }
+
+        results[task_name] = result
+
+        # Save result incrementally
+        if results_file:
+            with open(results_file, "a") as f:
+                f.write(json.dumps(result) + "\n")
+
+        if metrics["main_metric"] is not None:
+            print(f"Score: {metrics['main_metric']:.4f}")
+        else:
+            print("Score: No summary metric")
+
+    elapsed = time.time() - start_time
+    print(
+        f"\nEvaluation completed in {elapsed//3600:.0f}h {(elapsed%3600)//60:.0f}m {elapsed%60:.0f}s"
+    )
+
+    # Print summary
+    print("\n=== Final Results ===")
+    valid_results = []
+    for task_name, result in results.items():
+        main_metric = result["metrics"]["main_metric"]
+        print(
+            f"{task_name}: {main_metric:.4f}"
+            if main_metric is not None
+            else f"{task_name}: N/A"
+        )
+        if main_metric is not None:
+            valid_results.append(main_metric)
+
+    if valid_results:
+        average = np.mean(valid_results)
+        print(f"Average: {average:.4f}")
+
+    return results
+
+
+def evaluate_single_task(
+    task: str,
+    model_name: str,
+    checkpoint_path: Optional[str] = None,
+    data_root: Optional[str] = None,
+    batch_size: int = 64,
+    model_kwargs: Optional[Dict] = None,
+    sae_path: Optional[str] = None,
+    **kwargs,
+) -> Dict[str, Any]:
+    """
+    Evaluate ViT-Prisma model on a single task.
+
+    Args:
+        task: Task name for evaluation
+        model_name: Name of the ViT-Prisma model
+        checkpoint_path: Optional path to model checkpoint
+        data_root: Root directory for datasets
+        batch_size: Batch size for evaluation
+        model_kwargs: Optional additional model arguments
+        sae_path: Optional path to SAE weights
+        **kwargs: Additional arguments
+
+    Returns:
+        Dictionary containing evaluation metrics
+    """
+    # Create train_info structure
+    train_info = create_train_info(model_name, checkpoint_path, model_kwargs)
+
+    # Use the eval_utils infrastructure
+    metrics = evaluate_model(
+        task_key=task,
+        train_info=train_info,
+        data_root=data_root,
+        dataset_size=None,
+        batch_size=batch_size,
+        sae_path=sae_path,
+    )
+
+    return metrics
+
+
+def main():
+    """Main function for command-line interface."""
+    parser = argparse.ArgumentParser(
+        description="Evaluate ViT-Prisma models using CLIP benchmark (via eval_utils)"
+    )
+
+    # Model arguments
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        required=True,
+        help="Name of the ViT-Prisma model to evaluate",
+    )
+    parser.add_argument(
+        "--checkpoint_path",
+        type=str,
+        default=None,
+        help="Path to model checkpoint (optional)",
+    )
+
+    # Data arguments
+    parser.add_argument(
+        "--data_root",
+        type=str,
+        default=None,
+        help="Root directory for evaluation datasets",
+    )
+    parser.add_argument(
+        "--tasks_config",
+        type=str,
+        default=None,
+        help="Path to YAML file containing task configurations",
+    )
+
+    # Evaluation arguments
+    parser.add_argument(
+        "--batch_size", type=int, default=64, help="Batch size for evaluation"
+    )
+
+    # Output arguments
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default=None,
+        help="Directory to save evaluation results",
+    )
+
+    # Single task evaluation
+    parser.add_argument(
+        "--task",
+        type=str,
+        default=None,
+        help="Single task to evaluate (if specified, only this task will be run)",
+    )
+
+    # SAE arguments
+    parser.add_argument(
+        "--sae_path",
+        type=str,
+        default=None,
+        help="Path to SAE weights (optional)",
+    )
+
+    args = parser.parse_args()
+
+    # Set up logging
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
+
+    # Use default tasks config if not specified
+    if args.tasks_config is None:
+        # Use the clip_benchmark_tasks.yml in the same directory
+        current_dir = Path(__file__).parent
+        default_tasks_config = current_dir / "clip_benchmark_tasks.yml"
+        if default_tasks_config.exists():
+            args.tasks_config = str(default_tasks_config)
+
+    if args.task:
+        # Single task evaluation
+        print(f"Evaluating single task: {args.task}")
+        metrics = evaluate_single_task(
+            task=args.task,
+            model_name=args.model_name,
+            checkpoint_path=args.checkpoint_path,
+            data_root=args.data_root,
+            batch_size=args.batch_size,
+            sae_path=args.sae_path,
+        )
+        print(f"Results: {metrics}")
+    else:
+        # Multi-task evaluation
+        results = evaluate_vit_prisma_model(
+            model_name=args.model_name,
+            checkpoint_path=args.checkpoint_path,
+            tasks_config=args.tasks_config,
+            data_root=args.data_root,
+            output_dir=args.output_dir,
+            batch_size=args.batch_size,
+            sae_path=args.sae_path,
+        )
+
+    print("Evaluation completed successfully!")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/vit_prisma/models/model_config_registry.py
+++ b/src/vit_prisma/models/model_config_registry.py
@@ -4,8 +4,8 @@ Comprehensive Prisma Model Configurations
 Configs load directly from Huggingface/OpenCLIP, sometimes with overrides to be compatible with Prisma.
 """
 
-from typing import Dict, Any
 from enum import Enum
+from typing import Any, Dict
 
 from vit_prisma.utils.enums import ModelType
 
@@ -616,11 +616,27 @@ BASE_TEXT_CONFIG = {
     "layer_norm_pre": True,
 }
 
+BASE_TEXT_CONFIG_B = {
+    "d_model": 512,
+    "n_heads": 8,
+    "n_layers": 12,
+    "d_mlp": 2048,
+    "d_head": 64,
+    "vocab_size": 49408,
+    "context_length": 77,
+    "eps": 1e-5,
+    "normalization_type": "LN",
+    "layer_norm_pre": True,
+}
+
 # Text configurations for CLIP models
 OPEN_CLIP_TEXT_CONFIGS = {
     # Base models
     "open-clip:laion/CLIP-ViT-B-32-DataComp.XL-s13B-b90K": {
-        **BASE_TEXT_CONFIG,
+        **BASE_TEXT_CONFIG_B,
+    },
+    "open-clip:laion/CLIP-ViT-B-32-laion2B-s34B-b79K": {
+        **BASE_TEXT_CONFIG_B,
     },
     "open-clip:laion/CLIP-ViT-L-14-DataComp.XL-s13B-b90K": {
         **BASE_TEXT_CONFIG,


### PR DESCRIPTION
Adding the code path to evaluate open-clip models (with or w/o sae) with clip_benchmark, which contains a list of benchmarks for zero-shot classification and retrieval.

The added code is under src/vit_prisma/model_eval, I found two different place with evals and figured this one is better. Let me know if not the case, should be easy to move around. There is a README.md with details of this change and how to run.

The change in existing code should be minor, and shouldn't impact the existing logic. If there're tests or code path I should run to avoid regression please let me know.

Finally, to run this change, clip-benchmark package is required, please let me know whether it's preferred add it to requirements, or keep it on-demand.